### PR TITLE
disabling upload button while textfield empty

### DIFF
--- a/src/components/activities/content/editors/VideoEditor.tsx
+++ b/src/components/activities/content/editors/VideoEditor.tsx
@@ -205,7 +205,7 @@ export const VideoEditor = ({ id, value = '', onChange = () => {}, onDelete = ()
             onDelete();
           }
         }}
-        disabled={preview.mode !== 1}
+        disabled={step === 0 ? preview.mode !== 1 : !name}
         ariaLabelledBy={`video-edit-${id}`}
         ariaDescribedBy={`video-edit-${id}-desc`}
         loadingLabel="Upload de votre vidéo en cours..."


### PR DESCRIPTION
### Motivation

To solve a reported bug : https://trello.com/c/DY4tq83G/17-bug-lors-de-limport-dune-vid%C3%A9o-sur-1vilage

### Changes

Only changed the boolean passed to the modal component to disable both button on specific behavior

### Test

Go to the village page -> create an enigma -> Upload a video -> check if the button is disabled while the name text input isn't filled
