### PR TITLE
fix: displayed activity limit

### DIFF
--- a/src/components/accueil/Accueil.tsx
+++ b/src/components/accueil/Accueil.tsx
@@ -18,7 +18,6 @@ export const Accueil = () => {
     pelico: true,
   });
   const { activities } = useActivities({
-    limit: 50,
     page: 0,
     countries: Object.keys(filters.countries).filter((key) => filters.countries[key]),
     pelico: filters.pelico,


### PR DESCRIPTION
### Motivation

To solve this reported bug : https://trello.com/c/nagjtqDC/12-impossible-de-scroller-jusquen-bas-du-fil-dactivit%C3%A9-dans-le-village-monde-roumanie-france

### Changes

Remove the display limit for activities.

### Test

- `git checkout fix/displayed-activity-limit`
- Go to homepage
- If you create 51 activities you should see them all.
