### PR TITLE
feat(Activity): add new symbol activity & adapt components to display it

### DIFF
--- a/server/controllers/activity.ts
+++ b/server/controllers/activity.ts
@@ -255,7 +255,7 @@ const CREATE_SCHEMA: JSONSchemaType<CreateActivityData> = {
   properties: {
     type: {
       type: 'number',
-      enum: [ActivityType.PRESENTATION, ActivityType.QUESTION, ActivityType.GAME, ActivityType.ENIGME, ActivityType.DEFI, ActivityType.INDICE],
+      enum: [ActivityType.PRESENTATION, ActivityType.QUESTION, ActivityType.GAME, ActivityType.ENIGME, ActivityType.DEFI, ActivityType.INDICE, ActivityType.SYMBOL],
     },
     subType: {
       type: 'number',
@@ -283,7 +283,7 @@ const CREATE_SCHEMA: JSONSchemaType<CreateActivityData> = {
     responseType: {
       type: 'number',
       nullable: true,
-      enum: [null, ActivityType.PRESENTATION, ActivityType.QUESTION, ActivityType.GAME, ActivityType.ENIGME, ActivityType.DEFI],
+      enum: [null, ActivityType.PRESENTATION, ActivityType.QUESTION, ActivityType.GAME, ActivityType.ENIGME, ActivityType.DEFI, ActivityType.INDICE, ActivityType.SYMBOL],
     },
   },
   required: ['type'],

--- a/src/activity-types/anyActivity.ts
+++ b/src/activity-types/anyActivity.ts
@@ -8,6 +8,7 @@ import type { EditorContent } from './extendedActivity.types';
 import type { IndiceActivity } from './indice.types';
 import type { PresentationActivity } from './presentation.types';
 import type { QuestionActivity } from './question.types';
+import type { SymbolActivity } from './symbol.types';
 
 export const isPresentation = (activity: AnyActivity): activity is PresentationActivity => {
   return activity.type === ActivityType.PRESENTATION;
@@ -23,6 +24,9 @@ export const isDefi = (activity: AnyActivity): activity is DefiActivity => {
 };
 export const isIndice = (activity: AnyActivity): activity is IndiceActivity => {
   return activity.type === ActivityType.INDICE;
+};
+export const isSymbol = (activity: AnyActivity): activity is SymbolActivity => {
+  return activity.type === ActivityType.SYMBOL;
 };
 
 export const getAnyActivity = (activity: Activity): AnyActivity => {

--- a/src/activity-types/symbol.constants.ts
+++ b/src/activity-types/symbol.constants.ts
@@ -1,0 +1,45 @@
+export const SYMBOL = {
+  DRAPEAU: 0,
+  EMBLEME: 1,
+  FLEUR: 2,
+  DEVISE: 3,
+  HYMNE: 4,
+  ANIMAL: 5,
+  FIGURE: 6,
+  MONNAIE: 7,
+};
+
+export const SYMBOL_TYPES = [
+  {
+    title: 'Drapeau',
+    step1: 'Un drapeau',
+  },
+  {
+    title: 'Emblème',
+    step1: 'Un emblème',
+  },
+  {
+    title: 'Fleur nationale',
+    step1: 'Une fleur nationale',
+  },
+  {
+    title: 'Devise',
+    step1: 'Une devise',
+  },
+  {
+    title: 'Hymne',
+    step1: 'Un hymne',
+  },
+  {
+    title: 'Animal',
+    step1: 'Un animal national',
+  },
+  {
+    title: 'Figure',
+    step1: 'Une figure symbolique',
+  },
+  {
+    title: 'Monnaie',
+    step1: 'Une monnaie',
+  },
+];

--- a/src/activity-types/symbol.types.ts
+++ b/src/activity-types/symbol.types.ts
@@ -1,0 +1,8 @@
+import type { GenericExtendedActivity } from './extendedActivity.types';
+
+export type SymbolData = {
+  theme: number;
+  indiceContentIndex: number;
+};
+
+export type SymbolActivity = GenericExtendedActivity<SymbolData>;

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -15,6 +15,7 @@ import HomeIcon from 'src/svg/navigation/home-icon.svg';
 import IndiceIcon from 'src/svg/navigation/indice-culturel.svg';
 import KeyIcon from 'src/svg/navigation/key-icon.svg';
 import QuestionIcon from 'src/svg/navigation/question-icon.svg';
+import SymbolIcon from 'src/svg/navigation/symbol-icon.svg';
 import TargetIcon from 'src/svg/navigation/target-icon.svg';
 import UserIcon from 'src/svg/navigation/user-icon.svg';
 import { UserType } from 'types/user.type';
@@ -57,18 +58,25 @@ export const Navigation = (): JSX.Element => {
       icon: <IndiceIcon style={{ fill: 'currentcolor' }} width="1.4rem" />,
       disabled: false,
     },
+
+    {
+      label: 'Présenter un symbole',
+      path: '/symbole',
+      icon: <SymbolIcon style={{ fill: 'white' }} width="1.4rem" />,
+      disabled: false,
+    },
     {
       label: 'Poser une question',
       path: '/poser-une-question',
       icon: <QuestionIcon style={{ fill: 'currentcolor' }} width="1.4rem" />,
       disabled: !(selectedPhase <= phase),
     },
-    {
-      label: 'Voir mes activités',
-      path: '/mes-activites',
-      icon: <AgendaIcon style={{ fill: 'currentcolor' }} width="1.4rem" />,
-      disabled: !(selectedPhase <= phase),
-    },
+    // {
+    //   label: 'Voir mes activités',
+    //   path: '/mes-activites',
+    //   icon: <AgendaIcon style={{ fill: 'currentcolor' }} width="1.4rem" />,
+    //   disabled: !(selectedPhase <= phase),
+    // },
   ];
 
   const stepTwo: Tab[] = [

--- a/src/components/activities/ActivityCard/SymbolCard.tsx
+++ b/src/components/activities/ActivityCard/SymbolCard.tsx
@@ -1,0 +1,104 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import React from 'react';
+
+import { Button } from '@material-ui/core';
+
+import { SYMBOL_TYPES } from 'src/activity-types/symbol.constants';
+import type { SymbolActivity } from 'src/activity-types/symbol.types';
+import { RedButton } from 'src/components/buttons/RedButton';
+import { bgPage } from 'src/styles/variables.const';
+import { htmlToText } from 'src/utils';
+
+import { CommentIcon } from './CommentIcon';
+import type { ActivityCardProps } from './activity-card.types';
+
+export const SymbolCard = ({ activity, isSelf, noButtons, isDraft, showEditButtons, onDelete }: ActivityCardProps<SymbolActivity>) => {
+  const firstImage = React.useMemo(
+    () => activity.processedContent.slice(activity.data.indiceContentIndex, activity.processedContent.length).find((c) => c.type === 'image'),
+    [activity.processedContent, activity.data.indiceContentIndex],
+  );
+  const firstTextContent = React.useMemo(
+    () => activity.processedContent.slice(activity.data.indiceContentIndex, activity.processedContent.length).find((c) => c.type === 'text'),
+    [activity.processedContent, activity.data.indiceContentIndex],
+  );
+  const firstText = firstTextContent ? htmlToText(firstTextContent.value) : '';
+
+  const symbolType = SYMBOL_TYPES[activity.subType ?? 0] ?? SYMBOL_TYPES[0];
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'stretch',
+        justifyContent: 'flex-start',
+      }}
+    >
+      {firstImage && (
+        <div style={{ width: '40%', flexShrink: 0, padding: '0.25rem' }}>
+          <div
+            style={{
+              height: '100%',
+              width: '100%',
+              backgroundColor: bgPage,
+              position: 'relative',
+            }}
+          >
+            <Image layout="fill" objectFit="contain" src={firstImage.value} unoptimized />
+          </div>
+        </div>
+      )}
+      <div style={{ margin: '0.25rem', flex: 1, minWidth: 0 }}>
+        {activity.data.theme !== undefined && <h3 style={{ margin: '0 0.5rem 0.5rem' }}>{symbolType.title}</h3>}
+        <div style={{ margin: '0 0.5rem 1rem', height: `${firstImage ? 4 : 2}rem`, textAlign: 'justify' }}>
+          <div className="text multine-with-ellipsis break-long-words" style={{ maxHeight: `${firstImage ? 4 : 2}rem` }}>
+            {firstText}
+          </div>
+        </div>
+        {noButtons || (
+          <div style={{ textAlign: 'right' }}>
+            {!showEditButtons && (
+              <>
+                <CommentIcon count={activity.commentCount} activityId={activity.id} />
+                <Link href={`/activite/${activity.id}`} passHref>
+                  <Button component="a" color="primary" variant="outlined" href={`/activite/${activity.id}`}>
+                    {'Voir le symbole'}
+                  </Button>
+                </Link>
+              </>
+            )}
+            {isSelf && showEditButtons && (
+              <>
+                <Link
+                  href={
+                    isDraft && activity.data.draftUrl
+                      ? `${activity.data.draftUrl}?activity-id=${activity.id}`
+                      : `/symbole/3?activity-id=${activity.id}`
+                  }
+                  passHref
+                >
+                  <Button
+                    component="a"
+                    href={
+                      isDraft && activity.data.draftUrl
+                        ? `${activity.data.draftUrl}?activity-id=${activity.id}`
+                        : `/symbole/3?activity-id=${activity.id}`
+                    }
+                    color="secondary"
+                    variant="contained"
+                    style={{ marginLeft: '0.25rem' }}
+                  >
+                    Modifier
+                  </Button>
+                </Link>
+                <RedButton style={{ marginLeft: '0.25rem' }} onClick={onDelete}>
+                  Supprimer
+                </RedButton>
+              </>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/components/activities/ActivityCard/index.tsx
+++ b/src/components/activities/ActivityCard/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import Paper from '@material-ui/core/Paper';
 
-import { isDefi, isEnigme, isIndice, isPresentation, isQuestion } from 'src/activity-types/anyActivity';
+import { isDefi, isEnigme, isIndice, isPresentation, isQuestion, isSymbol } from 'src/activity-types/anyActivity';
 import { getEnigmeTimeLeft } from 'src/activity-types/enigme.constants';
 import { isMascotte, isThematique } from 'src/activity-types/presentation.constants';
 import { AvatarImg } from 'src/components/Avatar';
@@ -14,6 +14,7 @@ import GameIcon from 'src/svg/navigation/game-icon.svg';
 import IndiceIcon from 'src/svg/navigation/indice-culturel.svg';
 import KeyIcon from 'src/svg/navigation/key-icon.svg';
 import QuestionIcon from 'src/svg/navigation/question-icon.svg';
+import SymbolIcon from 'src/svg/navigation/symbol-icon.svg';
 import TargetIcon from 'src/svg/navigation/target-icon.svg';
 import UserIcon from 'src/svg/navigation/user-icon.svg';
 import PelicoNeutre from 'src/svg/pelico/pelico_neutre.svg';
@@ -27,6 +28,7 @@ import { IndiceCard } from './IndiceCard';
 import { MascotteCard } from './MascotteCard';
 import { PresentationCard } from './PresentationCard';
 import { QuestionCard } from './QuestionCard';
+import { SymbolCard } from './SymbolCard';
 import type { ActivityCardProps } from './activity-card.types';
 
 const titles = {
@@ -36,6 +38,7 @@ const titles = {
   [ActivityType.ENIGME]: 'créé une énigme',
   [ActivityType.QUESTION]: 'posé une question',
   [ActivityType.INDICE]: 'créé un indice culturel',
+  [ActivityType.SYMBOL]: 'créé un symbole',
 };
 const icons = {
   [ActivityType.PRESENTATION]: UserIcon,
@@ -44,6 +47,7 @@ const icons = {
   [ActivityType.ENIGME]: KeyIcon,
   [ActivityType.QUESTION]: QuestionIcon,
   [ActivityType.INDICE]: IndiceIcon,
+  [ActivityType.SYMBOL]: SymbolIcon,
 };
 
 export const ActivityCard = ({
@@ -163,6 +167,17 @@ export const ActivityCard = ({
         )}
         {isIndice(activity) && (
           <IndiceCard
+            activity={activity}
+            user={user}
+            isSelf={isSelf}
+            noButtons={noButtons}
+            showEditButtons={showEditButtons}
+            isDraft={isDraft}
+            onDelete={onDelete}
+          />
+        )}
+        {isSymbol(activity) && (
+          <SymbolCard
             activity={activity}
             user={user}
             isSelf={isSelf}

--- a/src/components/activities/ActivityComments/index.tsx
+++ b/src/components/activities/ActivityComments/index.tsx
@@ -20,6 +20,7 @@ const labels = {
   [ActivityType.ENIGME]: 'Réagir à cette activité par :',
   [ActivityType.QUESTION]: 'Répondre à cette question par :',
   [ActivityType.INDICE]: 'Répondre à cet indice culturel par :',
+  [ActivityType.SYMBOL]: 'Répondre à ce symbole par :',
 };
 
 interface ActivityCommentsProps {

--- a/src/components/activities/ActivityView/index.tsx
+++ b/src/components/activities/ActivityView/index.tsx
@@ -1,7 +1,7 @@
 import { useRouter } from 'next/router';
 import React from 'react';
 
-import { isPresentation, isQuestion, isEnigme, isDefi, isIndice } from 'src/activity-types/anyActivity';
+import { isPresentation, isQuestion, isEnigme, isDefi, isIndice, isSymbol } from 'src/activity-types/anyActivity';
 import { isThematique, isMascotte } from 'src/activity-types/presentation.constants';
 import { AvatarImg } from 'src/components/Avatar';
 import { Flag } from 'src/components/Flag';
@@ -26,6 +26,7 @@ const REACTIONS = {
   [ActivityType.ENIGME]: 'cette énigme',
   [ActivityType.QUESTION]: 'cette question',
   [ActivityType.INDICE]: 'cet indice culturel',
+  [ActivityType.SYMBOL]: 'ce symbole',
 };
 
 export const ActivityView = ({ activity, user }: ActivityViewProps) => {
@@ -69,6 +70,7 @@ export const ActivityView = ({ activity, user }: ActivityViewProps) => {
       {isEnigme(activity) && <EnigmeActivityView activity={activity} user={user} isAnswer={isAnswer} />}
       {isDefi(activity) && <DefiActivityView activity={activity} user={user} />}
       {isIndice(activity) && <ContentView content={activity.processedContent} />}
+      {isSymbol(activity) && <ContentView content={activity.processedContent} />}
     </div>
   );
 };

--- a/src/components/activities/List.tsx
+++ b/src/components/activities/List.tsx
@@ -20,6 +20,7 @@ const REACTIONS = {
   [ActivityType.ENIGME]: 'une énigme',
   [ActivityType.QUESTION]: 'une question',
   [ActivityType.INDICE]: 'un indice culturel',
+  [ActivityType.SYMBOL]: 'un symbole',
 };
 
 interface ActivitiesProps {

--- a/src/components/activities/content/editors/ImageEditor/ImageComponent.tsx
+++ b/src/components/activities/content/editors/ImageEditor/ImageComponent.tsx
@@ -1,0 +1,155 @@
+import Image from 'next/image';
+import { useSnackbar } from 'notistack';
+import React from 'react';
+
+import { Button, Divider, TextField } from '@material-ui/core';
+import CloudUploadIcon from '@material-ui/icons/CloudUpload';
+import { Alert } from '@material-ui/lab';
+
+import type { ImgCroppieRef } from 'src/components/ImgCroppie';
+import { ImgCroppie } from 'src/components/ImgCroppie';
+import { KeepRatio } from 'src/components/KeepRatio';
+import { Modal } from 'src/components/Modal';
+import { UserContext } from 'src/contexts/userContext';
+import { fontDetailColor, bgPage } from 'src/styles/variables.const';
+import { isValidHttpUrl } from 'src/utils';
+
+import type { EditorProps } from '../../content.types';
+
+
+export const ImageComponent = (useCrop: boolean) => {
+    const { axiosLoggedRequest } = React.useContext(UserContext);
+    const { enqueueSnackbar } = useSnackbar();
+    const previewRef = React.useRef<HTMLDivElement>(null);
+    const [tempImageUrl, setTempImageUrl] = React.useState('');
+    const [file, setFile] = React.useState<File | null>(null);
+    const [preview, setPreview] = React.useState<{ url: string; mode: number }>({
+      url: '',
+      mode: 0,
+    }); // 0 no preview, 1: preview, 2: error
+    const [previewSize, setPreviewSize] = React.useState(100);
+    const inputFile = React.useRef<HTMLInputElement>(null);
+    const croppieRef = React.useRef<ImgCroppieRef>(null);
+    const prevUpload = React.useRef<string | null>(null);
+
+
+    const displayPreview = () => {
+        setPreview({
+          mode: 1,
+          url: tempImageUrl,
+        });
+      };
+
+  const onFileSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const files = event.target.files;
+    const filesArr = Array.prototype.slice.call(files) as File[];
+    if (filesArr.length > 0) {
+      setFile(filesArr[0]);
+      setTempImageUrl(URL.createObjectURL(filesArr[0]));
+      setPreview({
+        mode: 1,
+        url: URL.createObjectURL(filesArr[0]),
+      });
+    } else {
+      setFile(null);
+      setTempImageUrl('');
+      resetPreview();
+    }
+  };
+  const uploadImage = async () => {
+
+    // delete previous uploaded image, not needed anymore.
+    if (prevUpload.current !== null) {
+      await axiosLoggedRequest({
+        method: 'DELETE',
+        url: prevUpload.current.slice(4),
+      });
+    }
+    const formData = new FormData();
+    if (useCrop) {
+      formData.append('image', await croppieRef.current.getBlob());
+    } else {
+      if (file === null) {
+        return;
+      }
+      formData.append('image', file);
+    }
+
+    const response = await axiosLoggedRequest({
+      method: 'POST',
+      url: '/images',
+      data: formData,
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    });
+    if (response.error) {
+      onChangeImage('');
+      prevUpload.current = null;
+      enqueueSnackbar('Une erreur est survenue...', {
+        variant: 'error',
+      });
+    } else {
+      onChangeImage(response.data.url);
+      prevUpload.current = response.data.url || null;
+      if (!response.data.url) {
+        enqueueSnackbar('Une erreur est survenue...', {
+          variant: 'error',
+        });
+      }
+    }
+  };
+
+  const resetPreview = () => {
+    setPreview({
+      mode: 0,
+      url: '',
+    });
+  };
+
+return (
+    <div style={{ display: 'flex', width: '100%' }}>
+    <div style={{ flex: '1', padding: '0.5rem', minWidth: 0 }}>
+    <div style={{ width: '100%', minHeight: '15rem', backgroundColor: bgPage, padding: '0.5rem' }}>
+        <div className="text-center text text--bold" style={{ height: '10%' }}>
+        Aperçu
+        </div>
+        {preview.mode === 1 && useCrop ? (
+        <div style={{ margin: '1rem 0' }}>
+            <KeepRatio ratio={1} width="70%">
+            <div
+                style={{
+                width: '100%',
+                height: '100%',
+                paddingBottom: '2rem',
+                }}
+                ref={previewRef}
+            >
+                <ImgCroppie
+                ref={croppieRef}
+                alt="preview"
+                src={preview.url}
+                imgWidth={previewSize * 0.8}
+                imgHeight={previewSize * 0.8}
+                type="circle"
+                />
+            </div>
+            </KeepRatio>
+        </div>
+        ) : preview.mode === 1 ? (
+        <div
+            style={{
+            width: '100%',
+            margin: '0.5rem 0',
+            height: '13rem',
+            position: 'relative',
+            }}
+        >
+            <Image layout="fill" objectFit="contain" src={preview.url} unoptimized />
+        </div>
+        ) : null}
+        {preview.mode === 2 && <Alert severity="error">{"Erreur: impossible de charger l'image."}</Alert>}
+    </div>
+    </div>
+    </div>
+)};

--- a/src/pages/activite/[id].tsx
+++ b/src/pages/activite/[id].tsx
@@ -23,6 +23,7 @@ const titles = {
   [ActivityType.ENIGME]: 'Énigme',
   [ActivityType.QUESTION]: 'Question',
   [ActivityType.INDICE]: 'Indice culturel',
+  [ActivityType.SYMBOL]: 'Symbole',
 };
 
 const Activity = () => {

--- a/src/pages/creer-une-enigme/5.tsx
+++ b/src/pages/creer-une-enigme/5.tsx
@@ -28,6 +28,7 @@ const REACTIONS = {
   [ActivityType.ENIGME]: 'cette énigme',
   [ActivityType.QUESTION]: 'cette question',
   [ActivityType.INDICE]: 'cet indice culturel',
+  [ActivityType.SYMBOL]: 'ce symbol',
 };
 
 const EnigmeStep5 = () => {

--- a/src/pages/indice-culturel/3.tsx
+++ b/src/pages/indice-culturel/3.tsx
@@ -85,7 +85,7 @@ const IndiceStep3 = () => {
           {isEdit ? (
             <div style={{ width: '100%', display: 'flex', justifyContent: 'space-between', margin: '1rem 0' }}>
               <Link href="/indice-culturel/2" passHref>
-                <Button component="a" color="secondary" variant="contained" href="/se-presenter/thematique/3">
+                <Button component="a" color="secondary" variant="contained" href="/indice-culture/2">
                   {"Modifier à l'étape précédente"}
                 </Button>
               </Link>

--- a/src/pages/lancer-un-defi/culinaire/5.tsx
+++ b/src/pages/lancer-un-defi/culinaire/5.tsx
@@ -29,6 +29,7 @@ const REACTIONS = {
   [ActivityType.ENIGME]: 'cette énigme',
   [ActivityType.QUESTION]: 'cette question',
   [ActivityType.INDICE]: 'cet indice culturel',
+  [ActivityType.SYMBOL]: 'ce symbol',
 };
 
 const DefiStep5 = () => {

--- a/src/pages/lancer-un-defi/ecologique/5.tsx
+++ b/src/pages/lancer-un-defi/ecologique/5.tsx
@@ -27,6 +27,7 @@ const REACTIONS = {
   [ActivityType.ENIGME]: 'cette énigme',
   [ActivityType.QUESTION]: 'cette question',
   [ActivityType.INDICE]: 'cet indice culturel',
+  [ActivityType.SYMBOL]: 'ce symbol',
 };
 
 const DefiEcoStep5 = () => {

--- a/src/pages/lancer-un-defi/linguistique/6.tsx
+++ b/src/pages/lancer-un-defi/linguistique/6.tsx
@@ -27,6 +27,7 @@ const REACTIONS = {
   [ActivityType.ENIGME]: 'cette énigme',
   [ActivityType.QUESTION]: 'cette question',
   [ActivityType.INDICE]: 'cet indice culturel',
+  [ActivityType.SYMBOL]: 'ce symbol',
 };
 
 const DefiStep6 = () => {

--- a/src/pages/symbole/1.tsx
+++ b/src/pages/symbole/1.tsx
@@ -1,0 +1,107 @@
+import { useRouter } from 'next/router';
+import React from 'react';
+
+import { isSymbol } from 'src/activity-types/anyActivity';
+import { SYMBOL_TYPES } from 'src/activity-types/symbol.constants';
+import { Base } from 'src/components/Base';
+import { StepsButton } from 'src/components/StepsButtons';
+import { Steps } from 'src/components/Steps';
+import type { FilterArgs } from 'src/components/accueil/Filters';
+import { Activities } from 'src/components/activities/List';
+import { ActivityContext } from 'src/contexts/activityContext';
+import { useActivities } from 'src/services/useActivities';
+import { getQueryString } from 'src/utils';
+import { ActivityType } from 'types/activity.type';
+
+const SymbolStep1 = () => {
+  const router = useRouter();
+  const { activity, createNewActivity, updateActivity } = React.useContext(ActivityContext);
+  const selectRef = React.useRef<HTMLDivElement>(null);
+
+  const [filters] = React.useState<FilterArgs>({
+    type: 0,
+    status: 0,
+    countries: {},
+    pelico: true,
+  });
+  const { activities } = useActivities({
+    page: 0,
+    countries: Object.keys(filters.countries).filter((key) => filters.countries[key]),
+    pelico: filters.pelico,
+    type: ActivityType.SYMBOL,
+  });
+  const sameActivities = activities.filter((c) => {
+    return c.subType === activity.subType;
+  });
+
+  // symbol sub-type
+  const symbolTypeIndex =
+    activity !== null && 'edit' in router.query && isSymbol(activity)
+      ? activity.subType ?? 0
+      : parseInt(getQueryString(router.query['category']) ?? '-1', 10) ?? 0;
+
+  const onNext = () => {
+    updateActivity({ responseActivityId: null, responseType: null });
+    router.push('/symbole/2');
+  };
+
+  const created = React.useRef(false);
+  React.useEffect(() => {
+    if (!created.current) {
+      created.current = true;
+      if (!('edit' in router.query)) {
+        const responseActivityId =
+          'responseActivityId' in router.query ? parseInt(getQueryString(router.query.responseActivityId), 10) ?? null : null;
+        const responseActivityType =
+          'responseActivityType' in router.query ? parseInt(getQueryString(router.query.responseActivityType), 10) ?? null : null;
+        createNewActivity(
+          ActivityType.SYMBOL,
+          symbolTypeIndex,
+          {
+            theme: 0,
+          },
+          responseActivityId,
+          responseActivityType,
+        );
+        if (responseActivityId !== null) {
+          if (selectRef.current) {
+            selectRef.current.scrollIntoView({ behavior: 'smooth' });
+          }
+        }
+      }
+    }
+  }, [activity, createNewActivity, symbolTypeIndex, router]);
+
+  if (!activity) {
+    return (
+      <Base>
+        <div></div>
+      </Base>
+    );
+  }
+
+  return (
+    <Base>
+      <div style={{ width: '100%', padding: '0.5rem 1rem 1rem 1rem' }}>
+        <Steps steps={[SYMBOL_TYPES[activity.subType]?.step1 ?? 'Symbole', 'Créer le symbole', 'Prévisualiser']} activeStep={0} />
+        <div className="width-900">
+          <p className="text">
+            Vous trouvez ici les symboles qui ont déjà été présentés par les Pélicopains de type &quot;
+            {SYMBOL_TYPES[activity.subType]?.step1}&quot;. N&apos;hésitez pas à y puiser de l&apos;inspiration, avant de proposer votre symbole ! Vous
+            pouvez également choisir de présenter un autre symbole, en revenant à l&apos;étape précédente.
+          </p>
+          <StepsButton prev="/symbole" next={onNext} />
+          <div>
+            {sameActivities.length > 0 ? (
+              <Activities activities={sameActivities} withLinks />
+            ) : (
+              <p className="center">Il n&apos;existe encore aucun symbole culturel sur le thème &quot;{SYMBOL_TYPES[activity.subType]?.title}&quot;</p>
+            )}
+          </div>
+        </div>
+      </div>
+    </Base>
+  );
+};
+
+export default SymbolStep1;

--- a/src/pages/symbole/2.tsx
+++ b/src/pages/symbole/2.tsx
@@ -1,0 +1,67 @@
+import { useRouter } from 'next/router';
+import React from 'react';
+
+import { isSymbol } from 'src/activity-types/anyActivity';
+import type { EditorContent } from 'src/activity-types/extendedActivity.types';
+import { SYMBOL_TYPES } from 'src/activity-types/symbol.constants';
+import type { SymbolData } from 'src/activity-types/symbol.types';
+import { Base } from 'src/components/Base';
+import { StepsButton } from 'src/components/StepsButtons';
+import { Steps } from 'src/components/Steps';
+import { ContentEditor } from 'src/components/activities/content';
+import { ActivityContext } from 'src/contexts/activityContext';
+import { ActivityStatus } from 'types/activity.type';
+
+const SymbolStep2 = () => {
+  const router = useRouter();
+  const { activity, updateActivity, addContent, deleteContent, save } = React.useContext(ActivityContext);
+
+  const data = (activity?.data as SymbolData) || null;
+  const isEdit = activity !== null && activity.id !== 0 && activity.status !== ActivityStatus.DRAFT;
+  const symbolContentIndex = data?.indiceContentIndex ?? 0;
+
+  React.useEffect(() => {
+    if (activity === null && !('activity-id' in router.query) && !sessionStorage.getItem('activity')) {
+      router.push('/symbole');
+    } else if (activity && !isSymbol(activity)) {
+      router.push('/symbole');
+    }
+  }, [activity, router]);
+
+  const updateContent = (content: EditorContent[]): void => {
+    updateActivity({ processedContent: [...activity.processedContent.slice(0, symbolContentIndex), ...content] });
+  };
+
+  const onNext = () => {
+    save().catch(console.error);
+    router.push('/symbole/3');
+  };
+
+  if (data === null || !('theme' in data) || data.theme === -1) {
+    return <div></div>;
+  }
+
+  return (
+    <Base>
+      <div style={{ width: '100%', padding: '0.5rem 1rem 1rem 1rem' }}>
+        <Steps steps={[SYMBOL_TYPES[activity.subType].step1 ?? 'Symbole', 'Créer le symbole', 'Prévisualiser']} activeStep={isEdit ? 0 : 1} />
+        <div className="width-900">
+          <h1>Faites une présentation libre de votre symbole</h1>
+          <p className="text">
+            Si vous souhaitez réaliser un film, n&apos;hésitez pas à utiliser Clap, un outil d&apos;aide à l&apos;écriture audiovisuel !
+          </p>
+          <ContentEditor
+            content={activity.processedContent}
+            updateContent={updateContent}
+            addContent={addContent}
+            deleteContent={deleteContent}
+            save={save}
+          />
+          <StepsButton prev="/symbole" next={onNext} />
+        </div>
+      </div>
+    </Base>
+  );
+};
+
+export default SymbolStep2;

--- a/src/pages/symbole/index.tsx
+++ b/src/pages/symbole/index.tsx
@@ -1,0 +1,101 @@
+import { useRouter } from 'next/router';
+import React from 'react';
+
+import { Base } from 'src/components/Base';
+import { ActivityChoice } from 'src/components/activities/ActivityChoice';
+import ObjetIcon from 'src/svg/enigme/objet-mystere.svg';
+
+const activities = [
+  {
+    label: 'Un drapeau',
+    href: '/symbole/1?category=0',
+    icon: ObjetIcon,
+    disabled: false,
+    disabledText: '',
+  },
+  {
+    label: 'Un emblème',
+    href: '/symbole/1?category=1',
+    icon: ObjetIcon,
+    disabled: false,
+    disabledText: '',
+  },
+  {
+    label: 'Une fleur nationale',
+    href: '/symbole/1?category=2',
+    icon: ObjetIcon,
+    disabled: false,
+    disabledText: '',
+  },
+  {
+    label: 'Une devise',
+    href: '/symbole/1?category=3',
+    icon: ObjetIcon,
+    disabled: false,
+    disabledText: '',
+  },
+  {
+    label: 'Un hymne',
+    href: '/symbole/1?category=4',
+    icon: ObjetIcon,
+    disabled: false,
+    disabledText: '',
+  },
+  {
+    label: 'Un animal national',
+    href: '/symbole/1?category=5',
+    icon: ObjetIcon,
+    disabled: false,
+    disabledText: '',
+  },
+  {
+    label: 'Une figure symbolique',
+    href: '/symbole/1?category=6',
+    icon: ObjetIcon,
+    disabled: false,
+    disabledText: '',
+  },
+  {
+    label: 'Une monnaie',
+    href: '/symbole/1?category=7',
+    icon: ObjetIcon,
+    disabled: false,
+    disabledText: '',
+  },
+];
+
+const Symbol = () => {
+  const router = useRouter();
+
+  const [activitiesWithLinks] = React.useMemo(() => {
+    if ('responseActivityId' in router.query && 'responseActivityType' in router.query) {
+      return [
+        activities.map((a) => ({
+          ...a,
+          href: `${a.href}&responseActivityId=${router.query.responseActivityId}&responseActivityType=${router.query.responseActivityType}`,
+        })),
+      ];
+    }
+    return [activities];
+  }, [router.query]);
+
+  return (
+    <Base>
+      <div style={{ width: '100%', padding: '0.5rem 1rem 1rem 1rem' }}>
+        <div className="width-900">
+          <h1>Quel symbole allez-vous présenter ?</h1>
+          <p className="text">
+            Dans cette activité, nous vous proposons de présenter à vos Pélicopains une fleur, un emblème, un hymne, un drapeau... un symbole, qui
+            représente le pays ou la région dans lequel vous habitez.
+          </p>
+          <p className="text">
+            Commencez par choisir quel type de symbole vous souhaitez présenter, ou choisissez de présenter un autre type de symbole.
+          </p>
+          <ActivityChoice activities={activitiesWithLinks} />
+        </div>
+      </div>
+    </Base>
+  );
+};
+
+export default Symbol;

--- a/src/pages/symbole/success.tsx
+++ b/src/pages/symbole/success.tsx
@@ -1,0 +1,30 @@
+import Link from 'next/link';
+import React from 'react';
+
+import { Button } from '@material-ui/core';
+
+import { Base } from 'src/components/Base';
+import { bgPage } from 'src/styles/variables.const';
+import PelicoSouriant from 'src/svg/pelico/pelico-souriant.svg';
+
+const IndiceSuccess = () => {
+  return (
+    <Base>
+      <div style={{ width: '100%', padding: '1rem 1rem 1rem 1rem' }}>
+        <div style={{ width: '100%', maxWidth: '20rem', margin: '4rem auto', backgroundColor: bgPage, padding: '1rem', borderRadius: '10px' }}>
+          <p className="text">Votre symbole a bien été publié !</p>
+          <PelicoSouriant style={{ width: '60%', height: 'auto', margin: '0 20%' }} />
+        </div>
+        <div className="text-center">
+          <Link href="/" passHref>
+            <Button component="a" href="/" variant="outlined" color="primary">
+              Retour à l’accueil
+            </Button>
+          </Link>
+        </div>
+      </div>
+    </Base>
+  );
+};
+
+export default IndiceSuccess;

--- a/src/svg/navigation/symbol-icon.svg
+++ b/src/svg/navigation/symbol-icon.svg
@@ -1,0 +1,4 @@
+<svg width="23" height="22" viewBox="0 0 23 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 14C1 14 2.27115 13 6.0846 13C9.89805 13 12.4404 15 16.2538 15C20.0673 15 21.3384 14 21.3384 14V2C21.3384 2 20.0673 3 16.2538 3C12.4404 3 9.89805 1 6.0846 1C2.27115 1 1 2 1 2V14Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M1 21V14" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/types/activity.type.ts
+++ b/types/activity.type.ts
@@ -7,6 +7,7 @@ export enum ActivityType {
   QUESTION = 3,
   GAME = 4,
   INDICE = 6,
+  SYMBOL = 7,
 }
 
 export enum ActivityStatus {


### PR DESCRIPTION
### Motivation

To solve this ticket : https://trello.com/c/GGZd7aaH/2-pr%C3%A9senter-un-symbole


### Changes

Add new pages to create activity
Add new activity type
Add new Icon for this activity
Update navigation links
Modify activity card to display symbol

### Test

git checkout feat/symbol-activity
In navigation component you should see "Présenter un symbole"
Click on link, you should be redirect to create symbol
Fill the form and try to play with this activity
Fill the form until step 3 whithout publish, you should see that draft version is save (go to "mes activités" to verify)
Publish and try to answer
Check the behavior of the new activity and its card.
