### PR TITLE
Order by pinned activities for backend

### DIFF
--- a/server/controllers/activity.ts
+++ b/server/controllers/activity.ts
@@ -119,7 +119,8 @@ const getActivities = async ({
   }
 
   const activities = await subQueryBuilder
-    .orderBy('activity.createDate', 'DESC')
+    .orderBy('activity.isPinned', 'DESC')
+    .addOrderBy('activity.createDate', 'DESC')
     .limit(limit)
     .offset(page * limit)
     .getMany();


### PR DESCRIPTION
### Motivation

Fix the order of the activities. Pinned activities should be first.