### PR TITLE
Clickable breadcrumb for mimic game

### DIFF
--- a/src/activity-types/game.constants.ts
+++ b/src/activity-types/game.constants.ts
@@ -1,4 +1,4 @@
-import type { MimicsData, GameMimicActivity, GameMoneyActivity, GameActivity } from '../../types/game.type';
+import type { MimicsData, GameMimicActivity, GameMoneyActivity, GameActivity, MimicData } from '../../types/game.type';
 import { GameType } from '../../types/game.type';
 
 export const DEFAULT_MIMIC_DATA: MimicsData = {
@@ -26,6 +26,21 @@ export const DEFAULT_MIMIC_DATA: MimicsData = {
     fakeSignification2: null,
     video: null,
   },
+};
+
+export const isMimicValid = (data: MimicData): boolean => {
+  return (
+    data.origine != null &&
+    data.origine.length > 0 &&
+    data.signification != null &&
+    data.signification.length > 0 &&
+    data.fakeSignification1 != null &&
+    data.fakeSignification1.length > 0 &&
+    data.fakeSignification2 != null &&
+    data.fakeSignification2.length > 0 &&
+    data.video != null &&
+    data.video.length > 0
+  );
 };
 
 export const isMimic = (activity: GameActivity): activity is GameMimicActivity => {

--- a/src/pages/creer-un-jeu/mimique/1.tsx
+++ b/src/pages/creer-un-jeu/mimique/1.tsx
@@ -66,7 +66,12 @@ const MimiqueStep1 = () => {
   return (
     <Base>
       <div style={{ width: '100%', padding: '0.5rem 1rem 1rem 1rem' }}>
-        <Steps steps={['1ère mimique', '2ème mimique', '3ème mimique', 'Prévisualiser']} activeStep={0} />
+        <Steps
+          steps={['1ère mimique', '2ème mimique', '3ème mimique', 'Prévisualiser']}
+          urls={['/creer-un-jeu/mimique/1?edit', '/creer-un-jeu/mimique/2', '/creer-un-jeu/mimique/3', '/creer-un-jeu/mimique/4']}
+          activeStep={0}
+        />
+
         <MimicSelector
           mimicNumber="1ère"
           MimicData={data.game1}

--- a/src/pages/creer-un-jeu/mimique/2.tsx
+++ b/src/pages/creer-un-jeu/mimique/2.tsx
@@ -13,6 +13,15 @@ const MimiqueStep2 = () => {
   const router = useRouter();
   const { activity, updateActivity } = React.useContext(ActivityContext);
 
+  const data = (activity?.data as MimicsData) || null;
+
+  const isValid = React.useMemo(() => {
+    if (activity !== null && activity.content.filter((c) => c.value.length > 0 && c.value !== '<p></p>\n').length === 0) {
+      return false;
+    }
+    return true;
+  }, [activity]);
+
   React.useEffect(() => {
     if (activity === null && !('activity-id' in router.query) && !sessionStorage.getItem('activity')) {
       router.push('/creer-un-jeu');
@@ -20,8 +29,6 @@ const MimiqueStep2 = () => {
       router.push('/creer-un-jeu');
     }
   }, [activity, router]);
-
-  const data = (activity?.data as MimicsData) || null;
 
   const dataChange = (key: keyof MimicData) => (event: React.ChangeEvent<HTMLInputElement>) => {
     const newData = { ...data };
@@ -54,7 +61,13 @@ const MimiqueStep2 = () => {
   return (
     <Base>
       <div style={{ width: '100%', padding: '0.5rem 1rem 1rem 1rem' }}>
-        <Steps steps={['1ère mimique', '2ème mimique', '3ème mimique', 'Prévisualiser']} activeStep={1} />
+        <Steps
+          steps={['1ère mimique', '2ème mimique', '3ème mimique', 'Prévisualiser']}
+          urls={['/creer-un-jeu/mimique/1?edit', '/creer-un-jeu/mimique/2', '/creer-un-jeu/mimique/3', '/creer-un-jeu/mimique/4']}
+          activeStep={1}
+          errorSteps={isValid ? [] : [0]}
+        />
+
         <MimicSelector
           mimicNumber="2ème"
           MimicData={data.game2}

--- a/src/pages/creer-un-jeu/mimique/2.tsx
+++ b/src/pages/creer-un-jeu/mimique/2.tsx
@@ -2,7 +2,7 @@ import { useRouter } from 'next/router';
 import React from 'react';
 
 import { isGame } from 'src/activity-types/anyActivity';
-import { isMimic } from 'src/activity-types/game.constants';
+import { isMimic, isMimicValid } from 'src/activity-types/game.constants';
 import { Base } from 'src/components/Base';
 import { Steps } from 'src/components/Steps';
 import MimicSelector from 'src/components/selectors/MimicSelector';
@@ -15,12 +15,12 @@ const MimiqueStep2 = () => {
 
   const data = (activity?.data as MimicsData) || null;
 
-  const isValid = React.useMemo(() => {
-    if (activity !== null && activity.content.filter((c) => c.value.length > 0 && c.value !== '<p></p>\n').length === 0) {
-      return false;
+  const isStep1Valid = React.useMemo(() => {
+    if (data !== null) {
+      return isMimicValid(data.game1);
     }
-    return true;
-  }, [activity]);
+    return false;
+  }, [data]);
 
   React.useEffect(() => {
     if (activity === null && !('activity-id' in router.query) && !sessionStorage.getItem('activity')) {
@@ -65,7 +65,7 @@ const MimiqueStep2 = () => {
           steps={['1ère mimique', '2ème mimique', '3ème mimique', 'Prévisualiser']}
           urls={['/creer-un-jeu/mimique/1?edit', '/creer-un-jeu/mimique/2', '/creer-un-jeu/mimique/3', '/creer-un-jeu/mimique/4']}
           activeStep={1}
-          errorSteps={isValid ? [] : [0]}
+          errorSteps={isStep1Valid ? [] : [0]}
         />
 
         <MimicSelector

--- a/src/pages/creer-un-jeu/mimique/2.tsx
+++ b/src/pages/creer-un-jeu/mimique/2.tsx
@@ -7,7 +7,6 @@ import { Base } from 'src/components/Base';
 import { Steps } from 'src/components/Steps';
 import MimicSelector from 'src/components/selectors/MimicSelector';
 import { ActivityContext } from 'src/contexts/activityContext';
-import { ActivityStatus } from 'types/activity.type';
 import type { MimicData, MimicsData } from 'types/game.type';
 
 const MimiqueStep2 = () => {

--- a/src/pages/creer-un-jeu/mimique/3.tsx
+++ b/src/pages/creer-un-jeu/mimique/3.tsx
@@ -13,6 +13,15 @@ const MimiqueStep3 = () => {
   const router = useRouter();
   const { activity, updateActivity } = React.useContext(ActivityContext);
 
+  const data = (activity?.data as MimicsData) || null;
+
+  const isValid = React.useMemo(() => {
+    if (activity !== null && activity.content.filter((c) => c.value.length > 0 && c.value !== '<p></p>\n').length === 0) {
+      return false;
+    }
+    return true;
+  }, [activity]);
+
   React.useEffect(() => {
     if (activity === null && !('activity-id' in router.query) && !sessionStorage.getItem('activity')) {
       router.push('/creer-un-jeu');
@@ -20,8 +29,6 @@ const MimiqueStep3 = () => {
       router.push('/creer-un-jeu');
     }
   }, [activity, router]);
-
-  const data = (activity?.data as MimicsData) || null;
 
   const dataChange = (key: keyof MimicData) => (event: React.ChangeEvent<HTMLInputElement>) => {
     const newData = { ...data };
@@ -54,7 +61,13 @@ const MimiqueStep3 = () => {
   return (
     <Base>
       <div style={{ width: '100%', padding: '0.5rem 1rem 1rem 1rem' }}>
-        <Steps steps={['1ère mimique', '2ème mimique', '3ème mimique', 'Prévisualiser']} activeStep={2} />
+        <Steps
+          steps={['1ère mimique', '2ème mimique', '3ème mimique', 'Prévisualiser']}
+          urls={['/creer-un-jeu/mimique/1?edit', '/creer-un-jeu/mimique/2', '/creer-un-jeu/mimique/3', '/creer-un-jeu/mimique/4']}
+          activeStep={2}
+          errorSteps={isValid ? [] : [0, 1]}
+        />
+
         <MimicSelector
           mimicNumber="3ème"
           MimicData={data.game3}

--- a/src/pages/creer-un-jeu/mimique/3.tsx
+++ b/src/pages/creer-un-jeu/mimique/3.tsx
@@ -7,7 +7,6 @@ import { Base } from 'src/components/Base';
 import { Steps } from 'src/components/Steps';
 import MimicSelector from 'src/components/selectors/MimicSelector';
 import { ActivityContext } from 'src/contexts/activityContext';
-import { ActivityStatus } from 'types/activity.type';
 import type { MimicData, MimicsData } from 'types/game.type';
 
 const MimiqueStep3 = () => {

--- a/src/pages/creer-un-jeu/mimique/3.tsx
+++ b/src/pages/creer-un-jeu/mimique/3.tsx
@@ -2,7 +2,7 @@ import { useRouter } from 'next/router';
 import React from 'react';
 
 import { isGame } from 'src/activity-types/anyActivity';
-import { isMimic } from 'src/activity-types/game.constants';
+import { isMimic, isMimicValid } from 'src/activity-types/game.constants';
 import { Base } from 'src/components/Base';
 import { Steps } from 'src/components/Steps';
 import MimicSelector from 'src/components/selectors/MimicSelector';
@@ -15,12 +15,12 @@ const MimiqueStep3 = () => {
 
   const data = (activity?.data as MimicsData) || null;
 
-  const isValid = React.useMemo(() => {
-    if (activity !== null && activity.content.filter((c) => c.value.length > 0 && c.value !== '<p></p>\n').length === 0) {
-      return false;
-    }
-    return true;
-  }, [activity]);
+  const errorSteps = React.useMemo(() => {
+    const errors: number[] = [];
+    if (!isMimicValid(data.game1)) errors.push(0); // step of mimic 1
+    if (!isMimicValid(data.game2)) errors.push(1); // step of mimic 2
+    return errors;
+  }, [data]);
 
   React.useEffect(() => {
     if (activity === null && !('activity-id' in router.query) && !sessionStorage.getItem('activity')) {
@@ -65,7 +65,7 @@ const MimiqueStep3 = () => {
           steps={['1ère mimique', '2ème mimique', '3ème mimique', 'Prévisualiser']}
           urls={['/creer-un-jeu/mimique/1?edit', '/creer-un-jeu/mimique/2', '/creer-un-jeu/mimique/3', '/creer-un-jeu/mimique/4']}
           activeStep={2}
-          errorSteps={isValid ? [] : [0, 1]}
+          errorSteps={errorSteps}
         />
 
         <MimicSelector

--- a/src/pages/creer-un-jeu/mimique/4.tsx
+++ b/src/pages/creer-un-jeu/mimique/4.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import { useRouter } from 'next/router';
 import type { SourceProps } from 'react-player/base';
 import ReactPlayer from 'react-player';
@@ -19,6 +20,13 @@ const MimiqueStep4 = () => {
   const { activity, save } = React.useContext(ActivityContext);
   const [isLoading, setIsLoading] = React.useState(false);
   const data = (activity?.data as MimicsData) || null;
+
+  const isValid = React.useMemo(() => {
+    if (activity !== null && activity.content.filter((c) => c.value.length > 0 && c.value !== '<p></p>\n').length === 0) {
+      return false;
+    }
+    return true;
+  }, [activity]);
 
   React.useEffect(() => {
     if (activity === null && !('activity-id' in router.query) && !sessionStorage.getItem('activity')) {
@@ -48,34 +56,45 @@ const MimiqueStep4 = () => {
   return (
     <Base>
       <div style={{ width: '100%', padding: '0.5rem 1rem 1rem 1rem' }}>
-        <Steps steps={['1ère mimique', '2ème mimique', '3ème mimique', 'Prévisualiser']} activeStep={3} />
+        <Steps
+          steps={['1ère mimique', '2ème mimique', '3ème mimique', 'Prévisualiser']}
+          urls={['/creer-un-jeu/mimique/1?edit', '/creer-un-jeu/mimique/2', '/creer-un-jeu/mimique/3', '/creer-un-jeu/mimique/4']}
+          activeStep={3}
+          errorSteps={isValid ? [] : [0, 1, 2]}
+        />
+
         <div className="width-900">
           <h1>Pré-visualisez votre mimiques et publiez les !</h1>
           <p style={{ width: '100%', textAlign: 'left', margin: '1rem 0' }}>
             Vous pouvez modifier chaque mimique si vous le souhaitez. Quand vous êtes prêts :
           </p>
+          {!isValid && (
+            <p>
+              <b>Avant de publier votre présentation, il faut corriger les étapes incomplètes, marquées en orange.</b>
+            </p>
+          )}
           <div style={{ width: '100%', textAlign: 'right', margin: '1rem 0' }}>
-            <Button variant="outlined" color="primary" onClick={onPublish}>
+            <Button variant="outlined" color="primary" onClick={onPublish} disabled={!isValid}>
               Publier
             </Button>
           </div>
           {/* Mimique 1 */}
-          <div className="preview-block">
+          <div className={classNames('preview-block', { 'preview-block--warning': !isValid })}>
             <Grid container spacing={3}>
               <Grid item xs={12} md={4}>
                 <ReactPlayer
                   width="100%"
                   height="100%"
                   light
-                  url={data.game1.video as string | string[] | SourceProps[] | MediaStream | undefined}
+                  url={isValid ? (data.game1.video as string | string[] | SourceProps[] | MediaStream | undefined) : ' '}
                   controls
                 />
               </Grid>
               <Grid item xs={12} md={6}>
                 <RadioGroup aria-label="signification" name="signification1" value={1}>
-                  <FormControlLabel value={1} control={<CustomRadio isChecked isSuccess />} label={data.game1.signification} />
-                  <FormControlLabel control={<Radio />} label={data.game1.fakeSignification1} />
-                  <FormControlLabel control={<Radio />} label={data.game1.fakeSignification2} />
+                  <FormControlLabel value={1} control={<CustomRadio isChecked isSuccess />} label={isValid ? data.game1.signification : ''} />
+                  <FormControlLabel control={<Radio />} label={isValid ? data.game1.fakeSignification1 : ''} />
+                  <FormControlLabel control={<Radio />} label={isValid ? data.game1.fakeSignification2 : ''} />
                 </RadioGroup>
               </Grid>
               <Grid item xs={12} md={2}>
@@ -83,29 +102,30 @@ const MimiqueStep4 = () => {
                   onClick={() => {
                     router.push(`/creer-un-jeu/mimique/1?edit=${activity.id}`);
                   }}
+                  status={isValid ? 'success' : 'warning'}
                   style={{ position: 'absolute', top: '40%', right: '0.5rem' }}
                 />
               </Grid>
             </Grid>
-            <p style={{ width: '100%', textAlign: 'left', margin: '0.3rem 1rem' }}>{data.game1.origine} </p>
+            <p style={{ width: '100%', textAlign: 'left', margin: '0.3rem 1rem' }}>{isValid ? data.game1.origine : ''} </p>
           </div>
           {/* Mimique 2 */}
-          <div className="preview-block">
+          <div className={classNames('preview-block', { 'preview-block--warning': !isValid })}>
             <Grid container spacing={3}>
               <Grid item xs={12} md={4}>
                 <ReactPlayer
                   width="100%"
                   height="100%"
                   light
-                  url={data.game2.video as string | string[] | SourceProps[] | MediaStream | undefined}
+                  url={isValid ? (data.game2.video as string | string[] | SourceProps[] | MediaStream | undefined) : ' '}
                   controls
                 />
               </Grid>
               <Grid item xs={12} md={6}>
                 <RadioGroup aria-label="signification" name="signification1" value={1}>
-                  <FormControlLabel value={1} control={<CustomRadio isChecked isSuccess />} label={data.game2.signification} />
-                  <FormControlLabel control={<Radio />} label={data.game2.fakeSignification1} />
-                  <FormControlLabel control={<Radio />} label={data.game2.fakeSignification2} />
+                  <FormControlLabel value={1} control={<CustomRadio isChecked isSuccess />} label={isValid ? data.game2.signification : ''} />
+                  <FormControlLabel control={<Radio />} label={isValid ? data.game2.fakeSignification1 : ''} />
+                  <FormControlLabel control={<Radio />} label={isValid ? data.game2.fakeSignification2 : ''} />
                 </RadioGroup>
               </Grid>
               <Grid item xs={12} md={2}>
@@ -113,29 +133,30 @@ const MimiqueStep4 = () => {
                   onClick={() => {
                     router.push('/creer-un-jeu/mimique/2');
                   }}
+                  status={isValid ? 'success' : 'warning'}
                   style={{ position: 'absolute', top: '40%', right: '0.5rem' }}
                 />
               </Grid>
             </Grid>
-            <p style={{ width: '100%', textAlign: 'left', margin: '0.3rem 1rem' }}>{data.game2.origine} </p>
+            <p style={{ width: '100%', textAlign: 'left', margin: '0.3rem 1rem' }}>{isValid ? data.game2.origine : ''} </p>
           </div>
           {/* Mimique 3 */}
-          <div className="preview-block">
+          <div className={classNames('preview-block', { 'preview-block--warning': !isValid })}>
             <Grid container spacing={3}>
               <Grid item xs={12} md={4}>
                 <ReactPlayer
                   width="100%"
                   height="100%"
                   light
-                  url={data.game3.video as string | string[] | SourceProps[] | MediaStream | undefined}
+                  url={isValid ? (data.game3.video as string | string[] | SourceProps[] | MediaStream | undefined) : ' '}
                   controls
                 />
               </Grid>
               <Grid item xs={12} md={6}>
                 <RadioGroup aria-label="signification" name="signification1" value={1}>
-                  <FormControlLabel value={1} control={<CustomRadio isChecked isSuccess />} label={data.game3.signification} />
-                  <FormControlLabel control={<Radio />} label={data.game3.fakeSignification1} />
-                  <FormControlLabel control={<Radio />} label={data.game3.fakeSignification2} />
+                  <FormControlLabel value={1} control={<CustomRadio isChecked isSuccess />} label={isValid ? data.game3.signification : ''} />
+                  <FormControlLabel control={<Radio />} label={isValid ? data.game3.fakeSignification1 : ''} />
+                  <FormControlLabel control={<Radio />} label={isValid ? data.game3.fakeSignification2 : ''} />
                 </RadioGroup>
               </Grid>
               <Grid item xs={12} md={2}>
@@ -143,11 +164,12 @@ const MimiqueStep4 = () => {
                   onClick={() => {
                     router.push('/creer-un-jeu/mimique/3');
                   }}
+                  status={isValid ? 'success' : 'warning'}
                   style={{ position: 'absolute', top: '40%', right: '0.5rem' }}
                 />
               </Grid>
             </Grid>
-            <p style={{ width: '100%', textAlign: 'left', margin: '0.3rem 1rem' }}>{data.game3.origine} </p>
+            <p style={{ width: '100%', textAlign: 'left', margin: '0.3rem 1rem' }}>{isValid ? data.game3.origine : ''} </p>
           </div>
         </div>
       </div>

--- a/src/pages/creer-un-jeu/mimique/4.tsx
+++ b/src/pages/creer-un-jeu/mimique/4.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { Grid, Button, Radio, RadioGroup, FormControlLabel, Backdrop, CircularProgress } from '@mui/material';
 
 import { isGame } from 'src/activity-types/anyActivity';
-import { isMimic } from 'src/activity-types/game.constants';
+import { isMimic, isMimicValid } from 'src/activity-types/game.constants';
 import { Base } from 'src/components/Base';
 import { Steps } from 'src/components/Steps';
 import { CustomRadio } from 'src/components/buttons/CustomRadio';
@@ -21,13 +21,15 @@ const MimiqueStep4 = () => {
   const [isLoading, setIsLoading] = React.useState(false);
   const data = (activity?.data as MimicsData) || null;
 
-  const isValid = React.useMemo(() => {
-    if (activity !== null && activity.content.filter((c) => c.value.length > 0 && c.value !== '<p></p>\n').length === 0) {
-      return false;
-    }
-    return true;
-  }, [activity]);
+  const errorSteps = React.useMemo(() => {
+    const errors: number[] = [];
+    if (!isMimicValid(data.game1)) errors.push(0); // step of mimic 1
+    if (!isMimicValid(data.game2)) errors.push(1); // step of mimic 2
+    if (!isMimicValid(data.game3)) errors.push(2); // step of mimic 3
+    return errors;
+  }, [data]);
 
+  const isValid = errorSteps.length === 0;
   React.useEffect(() => {
     if (activity === null && !('activity-id' in router.query) && !sessionStorage.getItem('activity')) {
       router.push('/creer-un-jeu');
@@ -60,7 +62,7 @@ const MimiqueStep4 = () => {
           steps={['1ère mimique', '2ème mimique', '3ème mimique', 'Prévisualiser']}
           urls={['/creer-un-jeu/mimique/1?edit', '/creer-un-jeu/mimique/2', '/creer-un-jeu/mimique/3', '/creer-un-jeu/mimique/4']}
           activeStep={3}
-          errorSteps={isValid ? [] : [0, 1, 2]}
+          errorSteps={errorSteps}
         />
 
         <div className="width-900">
@@ -79,22 +81,26 @@ const MimiqueStep4 = () => {
             </Button>
           </div>
           {/* Mimique 1 */}
-          <div className={classNames('preview-block', { 'preview-block--warning': !isValid })}>
+          <div className={classNames('preview-block', { 'preview-block--warning': errorSteps.includes(0) })}>
             <Grid container spacing={3}>
               <Grid item xs={12} md={4}>
                 <ReactPlayer
                   width="100%"
                   height="100%"
                   light
-                  url={isValid ? (data.game1.video as string | string[] | SourceProps[] | MediaStream | undefined) : ' '}
+                  url={errorSteps.includes(0) ? ' ' : (data.game1.video as string | string[] | SourceProps[] | MediaStream | undefined)}
                   controls
                 />
               </Grid>
               <Grid item xs={12} md={6}>
                 <RadioGroup aria-label="signification" name="signification1" value={1}>
-                  <FormControlLabel value={1} control={<CustomRadio isChecked isSuccess />} label={isValid ? data.game1.signification : ''} />
-                  <FormControlLabel control={<Radio />} label={isValid ? data.game1.fakeSignification1 : ''} />
-                  <FormControlLabel control={<Radio />} label={isValid ? data.game1.fakeSignification2 : ''} />
+                  <FormControlLabel
+                    value={1}
+                    control={<CustomRadio isChecked isSuccess />}
+                    label={errorSteps.includes(0) ? '' : data.game1.signification}
+                  />
+                  <FormControlLabel control={<Radio />} label={errorSteps.includes(0) ? '' : data.game1.fakeSignification1} />
+                  <FormControlLabel control={<Radio />} label={errorSteps.includes(0) ? '' : data.game1.fakeSignification2} />
                 </RadioGroup>
               </Grid>
               <Grid item xs={12} md={2}>
@@ -102,30 +108,34 @@ const MimiqueStep4 = () => {
                   onClick={() => {
                     router.push(`/creer-un-jeu/mimique/1?edit=${activity.id}`);
                   }}
-                  status={isValid ? 'success' : 'warning'}
+                  status={errorSteps.includes(0) ? 'warning' : 'success'}
                   style={{ position: 'absolute', top: '40%', right: '0.5rem' }}
                 />
               </Grid>
             </Grid>
-            <p style={{ width: '100%', textAlign: 'left', margin: '0.3rem 1rem' }}>{isValid ? data.game1.origine : ''} </p>
+            <p style={{ width: '100%', textAlign: 'left', margin: '0.3rem 1rem' }}>{errorSteps.includes(0) ? '' : data.game1.origine} </p>
           </div>
           {/* Mimique 2 */}
-          <div className={classNames('preview-block', { 'preview-block--warning': !isValid })}>
+          <div className={classNames('preview-block', { 'preview-block--warning': errorSteps.includes(1) })}>
             <Grid container spacing={3}>
               <Grid item xs={12} md={4}>
                 <ReactPlayer
                   width="100%"
                   height="100%"
                   light
-                  url={isValid ? (data.game2.video as string | string[] | SourceProps[] | MediaStream | undefined) : ' '}
+                  url={errorSteps.includes(1) ? ' ' : (data.game2.video as string | string[] | SourceProps[] | MediaStream | undefined)}
                   controls
                 />
               </Grid>
               <Grid item xs={12} md={6}>
                 <RadioGroup aria-label="signification" name="signification1" value={1}>
-                  <FormControlLabel value={1} control={<CustomRadio isChecked isSuccess />} label={isValid ? data.game2.signification : ''} />
-                  <FormControlLabel control={<Radio />} label={isValid ? data.game2.fakeSignification1 : ''} />
-                  <FormControlLabel control={<Radio />} label={isValid ? data.game2.fakeSignification2 : ''} />
+                  <FormControlLabel
+                    value={1}
+                    control={<CustomRadio isChecked isSuccess />}
+                    label={errorSteps.includes(1) ? '' : data.game2.signification}
+                  />
+                  <FormControlLabel control={<Radio />} label={errorSteps.includes(1) ? '' : data.game2.fakeSignification1} />
+                  <FormControlLabel control={<Radio />} label={errorSteps.includes(1) ? '' : data.game2.fakeSignification2} />
                 </RadioGroup>
               </Grid>
               <Grid item xs={12} md={2}>
@@ -133,30 +143,34 @@ const MimiqueStep4 = () => {
                   onClick={() => {
                     router.push('/creer-un-jeu/mimique/2');
                   }}
-                  status={isValid ? 'success' : 'warning'}
+                  status={errorSteps.includes(1) ? 'warning' : 'success'}
                   style={{ position: 'absolute', top: '40%', right: '0.5rem' }}
                 />
               </Grid>
             </Grid>
-            <p style={{ width: '100%', textAlign: 'left', margin: '0.3rem 1rem' }}>{isValid ? data.game2.origine : ''} </p>
+            <p style={{ width: '100%', textAlign: 'left', margin: '0.3rem 1rem' }}>{errorSteps.includes(1) ? '' : data.game2.origine} </p>
           </div>
           {/* Mimique 3 */}
-          <div className={classNames('preview-block', { 'preview-block--warning': !isValid })}>
+          <div className={classNames('preview-block', { 'preview-block--warning': errorSteps.includes(2) })}>
             <Grid container spacing={3}>
               <Grid item xs={12} md={4}>
                 <ReactPlayer
                   width="100%"
                   height="100%"
                   light
-                  url={isValid ? (data.game3.video as string | string[] | SourceProps[] | MediaStream | undefined) : ' '}
+                  url={errorSteps.includes(2) ? ' ' : (data.game3.video as string | string[] | SourceProps[] | MediaStream | undefined)}
                   controls
                 />
               </Grid>
               <Grid item xs={12} md={6}>
                 <RadioGroup aria-label="signification" name="signification1" value={1}>
-                  <FormControlLabel value={1} control={<CustomRadio isChecked isSuccess />} label={isValid ? data.game3.signification : ''} />
-                  <FormControlLabel control={<Radio />} label={isValid ? data.game3.fakeSignification1 : ''} />
-                  <FormControlLabel control={<Radio />} label={isValid ? data.game3.fakeSignification2 : ''} />
+                  <FormControlLabel
+                    value={1}
+                    control={<CustomRadio isChecked isSuccess />}
+                    label={errorSteps.includes(2) ? '' : data.game3.signification}
+                  />
+                  <FormControlLabel control={<Radio />} label={errorSteps.includes(2) ? '' : data.game3.fakeSignification1} />
+                  <FormControlLabel control={<Radio />} label={errorSteps.includes(2) ? '' : data.game3.fakeSignification2} />
                 </RadioGroup>
               </Grid>
               <Grid item xs={12} md={2}>
@@ -164,12 +178,12 @@ const MimiqueStep4 = () => {
                   onClick={() => {
                     router.push('/creer-un-jeu/mimique/3');
                   }}
-                  status={isValid ? 'success' : 'warning'}
+                  status={errorSteps.includes(2) ? 'warning' : 'success'}
                   style={{ position: 'absolute', top: '40%', right: '0.5rem' }}
                 />
               </Grid>
             </Grid>
-            <p style={{ width: '100%', textAlign: 'left', margin: '0.3rem 1rem' }}>{isValid ? data.game3.origine : ''} </p>
+            <p style={{ width: '100%', textAlign: 'left', margin: '0.3rem 1rem' }}>{errorSteps.includes(2) ? '' : data.game3.origine} </p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
### Motivation

Make the breadcrumb clickable for the mimic game like in phase 1.

### Changes

In the files /creer-un-jeu/mimique/ : 
- 1.tsx
- 2.tsx
- 3.tsx
- 4.tsx

### Test

Go to phase 2 and click on the button "creer-un-jeu". Then in the next page, click on the button "Faire découvrir 3 mimiques".
You can test theses changes with the breadcrumb in the the top of the page.
