### PR TITLE
Fix some linter bugs

### DIFF
--- a/server/controllers/game.ts
+++ b/server/controllers/game.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import type { JSONSchemaType } from 'ajv';
 import type { NextFunction, Request, Response } from 'express';
 import { getRepository } from 'typeorm';
@@ -76,7 +75,6 @@ gameController.get({ path: '/ableToPlay', userType: UserType.TEACHER }, async (r
   const userId = req.user.id;
   const villageId = req.user.villageId || Number(req.query.villageId);
   const type = req.query.type;
-  console.log('villageId : ' + villageId);
   const game = await getRepository(Game).createQueryBuilder('game').where('`game`.`userId` = :userId', { userId: userId }).getOne();
   const count = await getRepository(Game)
     .createQueryBuilder('game')
@@ -135,7 +133,6 @@ type UpdateActivity = {
   value: string;
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const ANSWER_M_SCHEMA: JSONSchemaType<UpdateActivity> = {
   type: 'object',
   properties: {

--- a/server/fileUpload/vimeo.ts
+++ b/server/fileUpload/vimeo.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { getRepository } from 'typeorm';
 import { Vimeo } from 'vimeo';
 
@@ -167,10 +166,8 @@ export class VimeoClass {
         },
         (error, body) => {
           if (error) {
-            // eslint-disable-next-line no-console
-            console.log('error');
-            // eslint-disable-next-line no-console
-            console.log(error);
+            logger.error(`Error getting picture for video: ${videoId}`);
+            logger.error(error);
           } else {
             resolve(body.pictures.uri);
           }
@@ -186,8 +183,8 @@ export class VimeoClass {
         },
         (error, body) => {
           if (error) {
-            console.log('error');
-            console.log(error);
+            logger.error(`Error getting picture for video: ${videoId}`);
+            logger.error(error);
           } else {
             resolve(body.sizes[2].link);
           }

--- a/server/utils/jsonSchemaValidator.ts
+++ b/server/utils/jsonSchemaValidator.ts
@@ -5,8 +5,6 @@ import Ajv from 'ajv';
 import { AppError, ErrorCode } from '../middlewares/handleErrors';
 
 const ajv = new Ajv();
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
 addFormats(ajv);
 
 export function sendInvalidDataError(validateFunction: ValidateFunction<unknown>): void {

--- a/server/utils/server.ts
+++ b/server/utils/server.ts
@@ -1,4 +1,3 @@
-/* eslint-disable sort-keys */
 import { logger } from './logger';
 
 /**

--- a/src/components/activities/ActivityCard/MimicCard.tsx
+++ b/src/components/activities/ActivityCard/MimicCard.tsx
@@ -31,7 +31,7 @@ export const MimicCard = ({ activity, isSelf, noButtons, isDraft, showEditButton
     return rdmMimicPick.video;
   }, [activityMimic]);
 
-  React.useMemo(() => {
+  React.useEffect(() => {
     if (village) {
       axiosLoggedRequest({
         method: 'GET',

--- a/src/components/activities/content/editors/VideoEditor/VideoModals.tsx
+++ b/src/components/activities/content/editors/VideoEditor/VideoModals.tsx
@@ -59,10 +59,11 @@ export const VideoModals: React.FC<VideoModalsProps> = ({
       prevValue.current = value;
       setVideoUrl(value || '');
     }
-  }, [value]);
+  }, [value, setVideoUrl]);
 
+  const prevIsModalOpen = React.useRef<boolean | null>(null);
   React.useEffect(() => {
-    if (isModalOpen) {
+    if (isModalOpen && isModalOpen !== prevIsModalOpen.current) {
       setProgress(-1);
       setStep(0);
       if (tempVideoUrl) {
@@ -72,7 +73,8 @@ export const VideoModals: React.FC<VideoModalsProps> = ({
         });
       }
     }
-  }, [isModalOpen]);
+    prevIsModalOpen.current = isModalOpen;
+  }, [isModalOpen, tempVideoUrl]);
 
   const displayPreview = async () => {
     if (ReactPlayer.canPlay(tempVideoUrl)) {
@@ -101,7 +103,7 @@ export const VideoModals: React.FC<VideoModalsProps> = ({
       onChange(newValue);
       setVideoUrl(newValue);
     },
-    [onChange],
+    [onChange, setVideoUrl],
   );
 
   const onFileSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -330,12 +332,7 @@ export const VideoModals: React.FC<VideoModalsProps> = ({
             <li style={{ margin: '0.2rem 0' }}>
               Vos vidéos mises en ligne sur 1village sont accessibles sur{' '}
               <Link href="/mes-videos">
-                <a
-                  href="/mes-videos"
-                  target="_blank"
-                  rel="noopener"
-                  style={{ display: 'inline-flex', alignItems: 'center', verticalAlign: 'bottom' }}
-                >
+                <a target="_blank" rel="noopener" style={{ display: 'inline-flex', alignItems: 'center', verticalAlign: 'bottom' }}>
                   <SettingsIcon /> {'->'} <i>mes vidéos</i>
                 </a>
               </Link>

--- a/src/pages/creer-un-jeu/mimique/index.tsx
+++ b/src/pages/creer-un-jeu/mimique/index.tsx
@@ -17,7 +17,7 @@ const Mimique: React.FC = () => {
   const [ableToPlay, setAbleToPlay] = React.useState<boolean>(false);
   const [count, setCount] = React.useState<number>(0);
 
-  React.useMemo(() => {
+  React.useEffect(() => {
     if (village) {
       axiosLoggedRequest({
         method: 'GET',

--- a/src/pages/creer-un-jeu/mimique/jouer.tsx
+++ b/src/pages/creer-un-jeu/mimique/jouer.tsx
@@ -40,6 +40,17 @@ function LinearProgressWithLabel(props: LinearProgressProps & { value: number })
   );
 }
 
+function shuffleArray(array: Array<number>) {
+  let i = array.length - 1;
+  for (; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    const temp = array[i];
+    array[i] = array[j];
+    array[j] = temp;
+  }
+  return array;
+}
+
 interface StatsProps {
   [key: string]: { [key: string]: number };
 }
@@ -65,7 +76,7 @@ const PlayMimique = () => {
   const [game, setGame] = React.useState<Game>();
   const [mimicContent, setMimicContent] = React.useState<MimicData>(mimicContentPropsDefault);
   const [gameResponses, setGameResponses] = React.useState<GameResponse[]>();
-  const [user, setUser] = React.useState<User>();
+  const [user, setUser] = React.useState<User | undefined>(undefined);
   const { axiosLoggedRequest } = React.useContext(UserContext);
   const [selected, setSelected] = React.useState<MimicResponseValue | null>(null);
   const [stats, setStats] = React.useState<StatsProps>();
@@ -119,7 +130,7 @@ const PlayMimique = () => {
           // Pick a random mimic game
           const randomGamePick = gameValues[Math.floor(Math.random() * gameValues.length)] as Game;
           setGame(randomGamePick);
-          const mimicContent = JSON.parse(randomGamePick.content) as unknown as MimicData;
+          const mimicContent = JSON.parse(randomGamePick.content) as MimicData;
           setMimicContent(mimicContent);
         } else {
           setLastMimiqueModalOpen(true);
@@ -131,7 +142,7 @@ const PlayMimique = () => {
   React.useEffect(() => {
     if (game) {
       const user = userMap[game.userId] !== undefined ? users[userMap[game.userId]] : undefined;
-      if (user && user.type !== UserType.OBSERVATOR) setUser(user as unknown as User);
+      if (user && user.type !== UserType.OBSERVATOR) setUser(user);
       if (user && user.type === UserType.OBSERVATOR) setUserIsPelico(false);
     }
   }, [game, userMap, users]);
@@ -247,17 +258,6 @@ const PlayMimique = () => {
         </Modal>
       </Base>
     );
-  }
-
-  function shuffleArray(array: Array<number>) {
-    let i = array.length - 1;
-    for (; i > 0; i--) {
-      const j = Math.floor(Math.random() * (i + 1));
-      const temp = array[i];
-      array[i] = array[j];
-      array[j] = temp;
-    }
-    return array;
   }
 
   return (


### PR DESCRIPTION
### Motivation

Fix some linter bugs

### Changes

- Remove some console logs.
- Remove old eslint disabled rules that are no longer necessary.
- Replace 2 useMemo with a useEffect instead. The pattern with the useMemo can not be used because of the async function call. And because the useMemo returns nothing, it makes no sense to use it. The useEffect is better here.
- Fix linter warnings in the `VideoModals.tsx` file.
- Move a static function outside a React component. (no need to declare it at each render.)
- Remove some `as unknown as ...` that leads to errors by fooling typescript.