### PR TITLE
Set the 'origin of the mimic' field to optional

### DIFF
--- a/src/activity-types/game.constants.ts
+++ b/src/activity-types/game.constants.ts
@@ -30,8 +30,6 @@ export const DEFAULT_MIMIC_DATA: MimicsData = {
 
 export const isMimicValid = (data: MimicData): boolean => {
   return (
-    data.origine != null &&
-    data.origine.length > 0 &&
     data.signification != null &&
     data.signification.length > 0 &&
     data.fakeSignification1 != null &&

--- a/src/components/activities/ActivityCard/MimicCard.tsx
+++ b/src/components/activities/ActivityCard/MimicCard.tsx
@@ -4,7 +4,6 @@ import React from 'react';
 
 import { Button } from '@mui/material';
 
-import { KeepRatio } from 'src/components/KeepRatio';
 import { RedButton } from 'src/components/buttons/RedButton';
 import { VillageContext } from 'src/contexts/villageContext';
 import { useGameRequests } from 'src/services/useGames';

--- a/src/components/activities/ActivityCard/ReportageCard.tsx
+++ b/src/components/activities/ActivityCard/ReportageCard.tsx
@@ -7,7 +7,6 @@ import { Button } from '@mui/material';
 
 import { getReportage } from 'src/activity-types/reportage.constants';
 import type { ReportageActivity } from 'src/activity-types/reportage.types';
-import { KeepRatio } from 'src/components/KeepRatio';
 import { RedButton } from 'src/components/buttons/RedButton';
 import { bgPage } from 'src/styles/variables.const';
 import { htmlToText } from 'src/utils';

--- a/src/components/selectors/MimicSelector.tsx
+++ b/src/components/selectors/MimicSelector.tsx
@@ -133,19 +133,16 @@ const MimicSelector = ({ MimicData, mimicNumber, onDataChange, onVideoChange, on
               label="Origine"
               value={MimicData.origine || ''}
               onChange={onDataChange('origine')}
-              style={{ width: '100%', margin: '10px' }}
-              error={showError && !isFieldValid(MimicData.origine)}
-              helperText={showError && !isFieldValid(MimicData.origine) ? 'Ce champ est obligatoire' : ''}
+              style={{ width: '100%', margin: '10px', fontStyle: 'italic' }}
+              helperText={'Ce champ est optionnel'}
               inputProps={{
                 maxLength: 800,
               }}
               multiline
             />
-            {!(showError && !isFieldValid(MimicData.origine)) && (
-              <div style={{ width: '100%', textAlign: 'right' }}>
-                <span className="text text--small">{MimicData.origine?.length}/800</span>
-              </div>
-            )}
+            <div style={{ width: '100%', textAlign: 'right' }}>
+              <span className="text text--small">{MimicData.origine?.length}/800</span>
+            </div>
           </Grid>
         </Grid>
         <h1>Inventez deux significations fausses à cette mimique</h1>

--- a/src/pages/creer-un-jeu/mimique/4.tsx
+++ b/src/pages/creer-un-jeu/mimique/4.tsx
@@ -115,7 +115,7 @@ const MimiqueStep4 = () => {
                 />
               </Grid>
             </Grid>
-            <p style={{ width: '100%', textAlign: 'left', margin: '0.3rem 1rem' }}>{errorSteps?.includes(0) ? '' : data.game1.origine} </p>
+            <p style={{ width: '100%', textAlign: 'left', margin: '0.3rem 1rem' }}>{data.game1.origine} </p>
           </div>
           {/* Mimique 2 */}
           <div className={classNames('preview-block', { 'preview-block--warning': errorSteps?.includes(1) })}>
@@ -150,7 +150,7 @@ const MimiqueStep4 = () => {
                 />
               </Grid>
             </Grid>
-            <p style={{ width: '100%', textAlign: 'left', margin: '0.3rem 1rem' }}>{errorSteps?.includes(1) ? '' : data.game2.origine} </p>
+            <p style={{ width: '100%', textAlign: 'left', margin: '0.3rem 1rem' }}>{data.game2.origine} </p>
           </div>
           {/* Mimique 3 */}
           <div className={classNames('preview-block', { 'preview-block--warning': errorSteps?.includes(2) })}>
@@ -185,7 +185,7 @@ const MimiqueStep4 = () => {
                 />
               </Grid>
             </Grid>
-            <p style={{ width: '100%', textAlign: 'left', margin: '0.3rem 1rem' }}>{errorSteps?.includes(2) ? '' : data.game3.origine} </p>
+            <p style={{ width: '100%', textAlign: 'left', margin: '0.3rem 1rem' }}>{data.game3.origine} </p>
           </div>
         </div>
       </div>

--- a/types/game.type.ts
+++ b/types/game.type.ts
@@ -47,7 +47,7 @@ export type MoneysData = {
 // --- structure of each mimique ---
 export type MimicData = {
   gameId: number | null;
-  origine: string | null;
+  origine?: string | null;
   signification: string | null;
   fakeSignification1: string | null;
   fakeSignification2: string | null;


### PR DESCRIPTION
### Motivation

**_Mimic origin_** field in mimic game should be optional.

### Changes

Removed error checking process from text field for "_**mimic origin**_".

### Test

Create a mimic game without filling the **_mimic origin_** field.
