### PR TITLE
adding the discussion space to mimic homepage

### DIFF
--- a/src/components/activities/ActivityCard/MimicCard.tsx
+++ b/src/components/activities/ActivityCard/MimicCard.tsx
@@ -69,7 +69,7 @@ export const MimicCard = ({ activity, isSelf, noButtons, isDraft, showEditButton
               <>
                 <CommentIcon count={activity.commentCount} activityId={activity.id} />
                 <Link href="/creer-un-jeu/mimique" passHref>
-                  <Button component="a" color="primary" variant="outlined" href="/creer-un-jeu/mimique" style={{ marginTop: '4rem' }}>
+                  <Button component="a" color="primary" variant="outlined" href="/creer-un-jeu/mimique">
                     Jouer au jeu
                   </Button>
                 </Link>

--- a/src/components/activities/ActivityCard/ReportageCard.tsx
+++ b/src/components/activities/ActivityCard/ReportageCard.tsx
@@ -73,13 +73,7 @@ export const ReportageCard = ({ activity, isSelf, noButtons, isDraft, showEditBu
             {!showEditButtons && (
               <>
                 <Link href={`/activite/${activity.id}`} passHref>
-                  <Button
-                    component="a"
-                    color="primary"
-                    variant="outlined"
-                    href={`/activite/${activity.id}`}
-                    style={{ marginTop: `${firstVideo ? 4 : 2}rem` }}
-                  >
+                  <Button component="a" color="primary" variant="outlined" href={`/activite/${activity.id}`}>
                     {'Voir le reportage'}
                   </Button>
                 </Link>

--- a/src/components/activities/ActivityComments/AddComment.tsx
+++ b/src/components/activities/ActivityComments/AddComment.tsx
@@ -7,6 +7,7 @@ import { AvatarImg } from 'src/components/Avatar';
 import { UserContext } from 'src/contexts/userContext';
 import { useCommentRequests } from 'src/services/useComments';
 import ReactionIcon from 'src/svg/navigation/reaction-icon.svg';
+import { ActivityType } from 'types/activity.type';
 
 const TextEditor = dynamic(() => import('src/components/activities/content/editors/TextEditor'), { ssr: false });
 
@@ -75,21 +76,22 @@ export const AddComment = ({ activityId, activityType, activityPhase }: AddComme
             )}
           </div>
         </div>
-        {activityPhase >= 2 && activityType !== 10 && (
-          <div style={{ marginLeft: '1rem' }}>
-            <p style={{ fontWeight: 600 }}>Ou bien réagissez en détail</p>
-            <Button
-              component="a"
-              href={`/reaction-activite/1?responseActivityId=${activityId}&responseActivityType=${activityType}`}
-              variant="outlined"
-              color="primary"
-              style={{ width: '100%' }}
-            >
-              <ReactionIcon />
-              Réagir
-            </Button>
-          </div>
-        )}
+        {(activityPhase >= 2 && activityType !== ActivityType.REACTION) ||
+          (activityType !== ActivityType.GAME && (
+            <div style={{ marginLeft: '1rem' }}>
+              <p style={{ fontWeight: 600 }}>Ou bien réagissez en détail</p>
+              <Button
+                component="a"
+                href={`/reaction-activite/1?responseActivityId=${activityId}&responseActivityType=${activityType}`}
+                variant="outlined"
+                color="primary"
+                style={{ width: '100%' }}
+              >
+                <ReactionIcon />
+                Réagir
+              </Button>
+            </div>
+          ))}
       </div>
     </div>
   );

--- a/src/components/activities/utils.ts
+++ b/src/components/activities/utils.ts
@@ -19,7 +19,7 @@ export const titles = {
   [ActivityType.CONTENU_LIBRE]: 'envoyé un message à ses Pélicopains',
   [ActivityType.INDICE]: 'créé un indice culturel',
   [ActivityType.SYMBOL]: 'créé un symbole',
-  [ActivityType.REPORTAGE]: 'réaliser un reportage',
+  [ActivityType.REPORTAGE]: 'réalisé un reportage',
   [ActivityType.REACTION]: 'réagi à',
 };
 

--- a/src/pages/reaction-activite/1.tsx
+++ b/src/pages/reaction-activite/1.tsx
@@ -20,7 +20,7 @@ const ReactionStep1 = () => {
   const { activity, createNewActivity, updateActivity } = React.useContext(ActivityContext);
   const selectRef = React.useRef<HTMLDivElement>(null);
   const [selectedActivity, setSelectedActivity] = React.useState<SelectedActivityInfos>({ id: null, type: null });
-  const activitiesTypes = [1, 2, 3, 4, 9];
+  const activitiesTypes = [ActivityType.ENIGME, ActivityType.DEFI, ActivityType.QUESTION, ActivityType.REPORTAGE];
 
   const onNext = () => {
     if (!activity || !isReaction(activity) || activity.responseActivityId !== selectedActivity.id) {


### PR DESCRIPTION
### Motivation

Removing the possibility to choose to react to a game.
Adding the discussion space to mimic homepage.

### Changes

Imported _ActivityComments_ component. However, some props are not dynamic. It's only a temporary solution.

### Test

Click on "play game". There is a discussion space available in mimic game homepage. Leave a comment. Go back to the main homepage. The comment is available.
