### PR TITLE
Correction for linguistique and mascotte

### DIFF
--- a/src/activity-types/mascotte.constants.ts
+++ b/src/activity-types/mascotte.constants.ts
@@ -26,7 +26,6 @@ export const DEFAULT_MASCOTTE_DATA: MascotteData = {
   wantedForeignLanguages: [],
   minorLanguages: [],
   fluentLanguages: [],
-  languages: [],
   currencies: [],
   classImg: '',
   classImgDesc: '',

--- a/src/activity-types/mascotte.types.ts
+++ b/src/activity-types/mascotte.types.ts
@@ -18,7 +18,6 @@ export type MascotteData = {
   personality2: string;
   personality3: string;
   countries: string[];
-  languages: string[];
   fluentLanguages: string[];
   minorLanguages: string[];
   wantedForeignLanguages: string[];

--- a/src/pages/lancer-un-defi/linguistique/1.tsx
+++ b/src/pages/lancer-un-defi/linguistique/1.tsx
@@ -112,7 +112,7 @@ const DefiStep1 = () => {
         },
       ];
     }
-    const l = (mascotte?.data as MascotteData)?.languages ?? [];
+    const l = (mascotte?.data as MascotteData)?.fluentLanguages ?? [];
     return l.reduce<{ label: string; value: string }[]>(
       (acc, l) => {
         if (l === 'fre') {


### PR DESCRIPTION
### Motivation

Correction for mascotte and linguistique parameters => languages deleted and replaced by fluentLanguages

### Changes

lancer-un-defi/1.tsx
mascotte.constants.ts
mascotte.types.ts

### Test
You need a mascotte created and then go to lancer un défi and choose linguistique. You should see the language list of the mascotte.