### PR TITLE
Fix for mimic responses + bug with overflow with very long text

### DIFF
--- a/src/components/activities/MimicStats.tsx
+++ b/src/components/activities/MimicStats.tsx
@@ -49,7 +49,7 @@ export const MimicStats = ({ gameResponses, choices, country, userMap, users }: 
   }, [choices]);
 
   return (
-    <Grid item xs={5} md={5}>
+    <Grid item xs={3} md={3}>
       <span style={{ paddingRight: '0.5rem' }}>{responseCount !== 0 ? 'Réponses de vos Pélicopains' : 'Pas de réponses de vos Pélicopains'}</span>
       <Flag country={country} />
       {responseCount > 0 && responseChoices && (

--- a/src/pages/creer-un-jeu/mimique/4.tsx
+++ b/src/pages/creer-un-jeu/mimique/4.tsx
@@ -100,9 +100,18 @@ const MimiqueStep4 = () => {
                     value={1}
                     control={<CustomRadio isChecked isSuccess />}
                     label={errorSteps?.includes(0) ? '' : data.game1.signification || ''}
+                    style={{ maxWidth: '100%' }}
                   />
-                  <FormControlLabel control={<Radio />} label={errorSteps?.includes(0) ? '' : data.game1.fakeSignification1 || ''} />
-                  <FormControlLabel control={<Radio />} label={errorSteps?.includes(0) ? '' : data.game1.fakeSignification2 || ''} />
+                  <FormControlLabel
+                    control={<Radio />}
+                    label={errorSteps?.includes(0) ? '' : data.game1.fakeSignification1 || ''}
+                    style={{ maxWidth: '100%' }}
+                  />
+                  <FormControlLabel
+                    control={<Radio />}
+                    label={errorSteps?.includes(0) ? '' : data.game1.fakeSignification2 || ''}
+                    style={{ maxWidth: '100%' }}
+                  />
                 </RadioGroup>
               </Grid>
               <Grid item xs={12} md={2}>
@@ -135,9 +144,18 @@ const MimiqueStep4 = () => {
                     value={1}
                     control={<CustomRadio isChecked isSuccess />}
                     label={errorSteps?.includes(1) ? '' : data.game2.signification || ''}
+                    style={{ maxWidth: '100%' }}
                   />
-                  <FormControlLabel control={<Radio />} label={errorSteps?.includes(1) ? '' : data.game2.fakeSignification1 || ''} />
-                  <FormControlLabel control={<Radio />} label={errorSteps?.includes(1) ? '' : data.game2.fakeSignification2 || ''} />
+                  <FormControlLabel
+                    control={<Radio />}
+                    label={errorSteps?.includes(1) ? '' : data.game2.fakeSignification1 || ''}
+                    style={{ maxWidth: '100%' }}
+                  />
+                  <FormControlLabel
+                    control={<Radio />}
+                    label={errorSteps?.includes(1) ? '' : data.game2.fakeSignification2 || ''}
+                    style={{ maxWidth: '100%' }}
+                  />
                 </RadioGroup>
               </Grid>
               <Grid item xs={12} md={2}>
@@ -154,7 +172,7 @@ const MimiqueStep4 = () => {
           </div>
           {/* Mimique 3 */}
           <div className={classNames('preview-block', { 'preview-block--warning': errorSteps?.includes(2) })}>
-            <Grid container spacing={3}>
+            <Grid container spacing={3} style={{ boxSizing: 'border-box' }}>
               <Grid item xs={12} md={4}>
                 <ReactPlayer
                   width="100%"
@@ -170,9 +188,18 @@ const MimiqueStep4 = () => {
                     value={1}
                     control={<CustomRadio isChecked isSuccess />}
                     label={errorSteps?.includes(2) ? '' : data.game3.signification || ''}
+                    style={{ maxWidth: '100%' }}
                   />
-                  <FormControlLabel control={<Radio />} label={errorSteps?.includes(2) ? '' : data.game3.fakeSignification1 || ''} />
-                  <FormControlLabel control={<Radio />} label={errorSteps?.includes(2) ? '' : data.game3.fakeSignification2 || ''} />
+                  <FormControlLabel
+                    control={<Radio />}
+                    label={errorSteps?.includes(2) ? '' : data.game3.fakeSignification1 || ''}
+                    style={{ maxWidth: '100%' }}
+                  />
+                  <FormControlLabel
+                    control={<Radio />}
+                    label={errorSteps?.includes(2) ? '' : data.game3.fakeSignification2 || ''}
+                    style={{ maxWidth: '100%' }}
+                  />
                 </RadioGroup>
               </Grid>
               <Grid item xs={12} md={2}>

--- a/src/pages/creer-un-jeu/mimique/jouer.tsx
+++ b/src/pages/creer-un-jeu/mimique/jouer.tsx
@@ -180,7 +180,7 @@ const PlayMimique = () => {
           <Grid item xs={12} md={12}>
             {mimicContent !== undefined && mimicContent.video !== null && <VideoView id={0} value={mimicContent.video}></VideoView>}
           </Grid>
-          <Grid item xs={2} md={2}>
+          <Grid item xs={2} md={4}>
             <RadioGroup value={selected} onChange={onChange} style={{ marginTop: '1.6rem' }}>
               {choices &&
                 choices.map((val) => {
@@ -192,7 +192,7 @@ const PlayMimique = () => {
                         control={found || foundError ? <GreenRadio isSuccess isChecked /> : <Radio />}
                         label={mimicContent?.signification || ''}
                         disabled={found || foundError ? true : false}
-                        style={{ cursor: 'pointer' }}
+                        style={{ cursor: 'pointer', width: '100%' }}
                       />
                     );
                   } else if (val === 1) {
@@ -203,7 +203,7 @@ const PlayMimique = () => {
                         control={fake1Selected ? <RedRadio isChecked /> : <Radio />}
                         label={mimicContent?.fakeSignification1 || ''}
                         disabled={fake1Selected || found || foundError ? true : false}
-                        style={{ cursor: 'pointer' }}
+                        style={{ cursor: 'pointer', width: '100%' }}
                       />
                     );
                   } else {
@@ -214,7 +214,7 @@ const PlayMimique = () => {
                         control={fake2Selected ? <RedRadio isChecked /> : <Radio />}
                         label={mimicContent?.fakeSignification2 || ''}
                         disabled={fake2Selected || found || foundError ? true : false}
-                        style={{ cursor: 'pointer' }}
+                        style={{ cursor: 'pointer', width: '100%' }}
                       />
                     );
                   }


### PR DESCRIPTION
### Motivation

Mimic responses did not have enough space. Needed to be fixed 

### Changes

<!-- List you changes -->
src/components/activities/MimicStats.tsx
src/pages/creer-un-jeu/mimique/jouer.tsx
src/pages/creer-un-jeu/mimique/4.tsx

### Test

![image](https://user-images.githubusercontent.com/75479164/152553232-cc23fe01-8d12-4de9-b248-7f2bbb4456fd.png)
More space added to the responses Grid (black border in the picture) and the mismicStats are smaller now
