### PR TITLE
Observator can't publish any activities but can play

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
             "type": "pwa-chrome",
             "request": "launch",
             "name": "Launch Chrome against localhost",
-            "url": "http://localhost:8080",
+            "url": "http://localhost:5000",
             "webRoot": "${workspaceFolder}"
         }
     ]

--- a/server/controllers/game.ts
+++ b/server/controllers/game.ts
@@ -124,6 +124,7 @@ gameController.get({ path: '/stats/:gameId', userType: UserType.TEACHER }, async
     .createQueryBuilder('gameResponse')
     .leftJoinAndSelect('gameResponse.user', 'user')
     .where('`gameResponse`.`gameId` = :gameId', { gameId: gameId })
+    .andWhere('user.type <> :userType', { userType: UserType.OBSERVATOR }) //Observator can play but don't affect the stats
     .getMany();
 
   res.sendJSON(gameResponses || []);

--- a/src/pages/creer-un-jeu/mimique/4.tsx
+++ b/src/pages/creer-un-jeu/mimique/4.tsx
@@ -4,7 +4,7 @@ import type { SourceProps } from 'react-player/base';
 import ReactPlayer from 'react-player';
 import React from 'react';
 
-import { Grid, Button, Radio, RadioGroup, FormControlLabel, Backdrop, CircularProgress } from '@mui/material';
+import { Grid, Button, Radio, RadioGroup, FormControlLabel, Backdrop, CircularProgress, Tooltip } from '@mui/material';
 
 import { isGame } from 'src/activity-types/anyActivity';
 import { isMimic, isMimicValid } from 'src/activity-types/game.constants';
@@ -13,13 +13,17 @@ import { Steps } from 'src/components/Steps';
 import { CustomRadio } from 'src/components/buttons/CustomRadio';
 import { EditButton } from 'src/components/buttons/EditButton';
 import { ActivityContext } from 'src/contexts/activityContext';
+import { UserContext } from 'src/contexts/userContext';
 import type { MimicsData } from 'types/game.type';
+import { UserType } from 'types/user.type';
 
 const MimiqueStep4 = () => {
   const router = useRouter();
   const { activity, save } = React.useContext(ActivityContext);
+  const { user } = React.useContext(UserContext);
   const [isLoading, setIsLoading] = React.useState(false);
   const data = (activity?.data as MimicsData) || null;
+  const isUserObservator = user?.type === UserType.OBSERVATOR;
 
   const errorSteps = React.useMemo(() => {
     const errors: number[] = [];
@@ -78,9 +82,19 @@ const MimiqueStep4 = () => {
             </p>
           )}
           <div style={{ width: '100%', textAlign: 'right', margin: '1rem 0' }}>
-            <Button variant="outlined" color="primary" onClick={onPublish} disabled={!isValid}>
-              Publier
-            </Button>
+            {isUserObservator ? (
+              <Tooltip title="Action non autorisée" arrow>
+                <span>
+                  <Button variant="outlined" color="primary" onClick={onPublish} disabled>
+                    Publier
+                  </Button>
+                </span>
+              </Tooltip>
+            ) : (
+              <Button variant="outlined" color="primary" onClick={onPublish} disabled={!isValid}>
+                Publier
+              </Button>
+            )}
           </div>
           {/* Mimique 1 */}
           <div className={classNames('preview-block', { 'preview-block--warning': errorSteps?.includes(0) })}>

--- a/src/pages/creer-un-jeu/mimique/4.tsx
+++ b/src/pages/creer-un-jeu/mimique/4.tsx
@@ -85,7 +85,7 @@ const MimiqueStep4 = () => {
             {isUserObservator ? (
               <Tooltip title="Action non autorisée" arrow>
                 <span>
-                  <Button variant="outlined" color="primary" onClick={onPublish} disabled>
+                  <Button variant="outlined" color="primary" disabled>
                     Publier
                   </Button>
                 </span>

--- a/src/pages/creer-une-enigme/4.tsx
+++ b/src/pages/creer-une-enigme/4.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import Backdrop from '@mui/material/Backdrop';
 import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
+import { Tooltip } from '@mui/material';
 
 import { isEnigme } from 'src/activity-types/anyActivity';
 import { ENIGME_TYPES, ENIGME_DATA } from 'src/activity-types/enigme.constants';
@@ -17,16 +18,20 @@ import { ContentView } from 'src/components/activities/content/ContentView';
 import { getErrorSteps } from 'src/components/activities/enigmeChecks';
 import { EditButton } from 'src/components/buttons/EditButton';
 import { ActivityContext } from 'src/contexts/activityContext';
+import { UserContext } from 'src/contexts/userContext';
 import { capitalize } from 'src/utils';
 import { ActivityStatus } from 'types/activity.type';
+import { UserType } from 'types/user.type';
 
 const EnigmeStep4 = () => {
   const router = useRouter();
   const { activity, save } = React.useContext(ActivityContext);
+  const { user } = React.useContext(UserContext);
   const [isLoading, setIsLoading] = React.useState(false);
 
   const data = (activity?.data as EnigmeData) || null;
   const isEdit = activity !== null && activity.id !== 0 && activity.status !== ActivityStatus.DRAFT;
+  const isUserObservator = user?.type === UserType.OBSERVATOR;
   const indiceContentIndex = data?.indiceContentIndex ?? 0;
 
   const errorSteps = React.useMemo(() => {
@@ -100,18 +105,28 @@ const EnigmeStep4 = () => {
               </Button>
             </div>
           ) : (
-            <div style={{ width: '100%', textAlign: 'right', margin: '1rem 0' }}>
+            <>
               {!isValid && (
                 <p>
                   <b>Avant de publier votre présentation, il faut corriger les étapes incomplètes, marquées en orange.</b>
                 </p>
               )}
               <div style={{ width: '100%', textAlign: 'right', margin: '1rem 0' }}>
-                <Button variant="outlined" color="primary" onClick={onPublish} disabled={!isValid}>
-                  Publier
-                </Button>
+                {isUserObservator ? (
+                  <Tooltip title="Action non autorisée" arrow>
+                    <span>
+                      <Button variant="outlined" color="primary" onClick={onPublish} disabled>
+                        Publier
+                      </Button>
+                    </span>
+                  </Tooltip>
+                ) : (
+                  <Button variant="outlined" color="primary" onClick={onPublish} disabled={!isValid}>
+                    Publier
+                  </Button>
+                )}
               </div>
-            </div>
+            </>
           )}
 
           <span className={classNames('text text--small text--success', { 'text text--small text--warning': !isValid && errorSteps.includes(0) })}>

--- a/src/pages/creer-une-enigme/4.tsx
+++ b/src/pages/creer-une-enigme/4.tsx
@@ -115,7 +115,7 @@ const EnigmeStep4 = () => {
                 {isUserObservator ? (
                   <Tooltip title="Action non autorisée" arrow>
                     <span>
-                      <Button variant="outlined" color="primary" onClick={onPublish} disabled>
+                      <Button variant="outlined" color="primary" disabled>
                         Publier
                       </Button>
                     </span>

--- a/src/pages/indice-culturel/3.tsx
+++ b/src/pages/indice-culturel/3.tsx
@@ -106,7 +106,7 @@ const IndiceStep3 = () => {
                 {isUserObservator ? (
                   <Tooltip title="Action non autorisée" arrow>
                     <span>
-                      <Button variant="outlined" color="primary" onClick={onPublish} disabled>
+                      <Button variant="outlined" color="primary" disabled>
                         Publier
                       </Button>
                     </span>

--- a/src/pages/indice-culturel/3.tsx
+++ b/src/pages/indice-culturel/3.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import Backdrop from '@mui/material/Backdrop';
 import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
+import { Tooltip } from '@mui/material';
 
 import { isIndice } from 'src/activity-types/anyActivity';
 import { getIndice } from 'src/activity-types/indice.constants';
@@ -16,14 +17,18 @@ import { Steps } from 'src/components/Steps';
 import { ContentView } from 'src/components/activities/content/ContentView';
 import { EditButton } from 'src/components/buttons/EditButton';
 import { ActivityContext } from 'src/contexts/activityContext';
+import { UserContext } from 'src/contexts/userContext';
 import { ActivityStatus } from 'types/activity.type';
+import { UserType } from 'types/user.type';
 
 const IndiceStep3 = () => {
   const router = useRouter();
   const { activity, save } = React.useContext(ActivityContext);
+  const { user } = React.useContext(UserContext);
   const [isLoading, setIsLoading] = React.useState(false);
 
   const isEdit = activity !== null && activity.id !== 0 && activity.status !== ActivityStatus.DRAFT;
+  const isUserObservator = user?.type === UserType.OBSERVATOR;
   const data = (activity?.data as IndiceData) || null;
 
   const isValid = React.useMemo(() => {
@@ -86,16 +91,33 @@ const IndiceStep3 = () => {
                   {"Modifier à l'étape précédente"}
                 </Button>
               </Link>
-              <Button variant="outlined" color="primary" onClick={onPublish}>
+              <Button variant="outlined" color="primary" onClick={onPublish} disabled={isUserObservator}>
                 Enregistrer les changements
               </Button>
             </div>
           ) : (
-            <div style={{ width: '100%', textAlign: 'right', margin: '1rem 0' }}>
-              <Button variant="outlined" color="primary" onClick={onPublish} disabled={!isValid}>
-                Publier
-              </Button>
-            </div>
+            <>
+              {!isValid && (
+                <p>
+                  <b>Avant de publier votre présentation, il faut corriger les étapes incomplètes, marquées en orange.</b>
+                </p>
+              )}
+              <div style={{ width: '100%', textAlign: 'right', margin: '1rem 0' }}>
+                {isUserObservator ? (
+                  <Tooltip title="Action non autorisée" arrow>
+                    <span>
+                      <Button variant="outlined" color="primary" onClick={onPublish} disabled>
+                        Publier
+                      </Button>
+                    </span>
+                  </Tooltip>
+                ) : (
+                  <Button variant="outlined" color="primary" onClick={onPublish} disabled={!isValid}>
+                    Publier
+                  </Button>
+                )}
+              </div>
+            </>
           )}
 
           <span className={'text text--small text--success'}>Thème</span>

--- a/src/pages/lancer-un-defi/culinaire/4.tsx
+++ b/src/pages/lancer-un-defi/culinaire/4.tsx
@@ -106,7 +106,7 @@ const DefiStep4 = () => {
                 {isUserObservator ? (
                   <Tooltip title="Action non autorisée" arrow>
                     <span>
-                      <Button variant="outlined" color="primary" onClick={onPublish} disabled>
+                      <Button variant="outlined" color="primary" disabled>
                         Publier
                       </Button>
                     </span>

--- a/src/pages/lancer-un-defi/culinaire/4.tsx
+++ b/src/pages/lancer-un-defi/culinaire/4.tsx
@@ -8,6 +8,7 @@ import Backdrop from '@mui/material/Backdrop';
 import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
 import Grid from '@mui/material/Grid';
+import { Tooltip } from '@mui/material';
 
 import { isDefi } from 'src/activity-types/anyActivity';
 import { isCooking, getDefi, DEFI } from 'src/activity-types/defi.constants';
@@ -19,15 +20,19 @@ import { ContentView } from 'src/components/activities/content/ContentView';
 import { getErrorSteps } from 'src/components/activities/defiChecksCooking';
 import { EditButton } from 'src/components/buttons/EditButton';
 import { ActivityContext } from 'src/contexts/activityContext';
+import { UserContext } from 'src/contexts/userContext';
 import { ActivityStatus } from 'types/activity.type';
+import { UserType } from 'types/user.type';
 
 const DefiStep4 = () => {
   const router = useRouter();
   const { activity, save } = React.useContext(ActivityContext);
+  const { user } = React.useContext(UserContext);
   const [isLoading, setIsLoading] = React.useState(false);
 
   const data = (activity?.data as CookingDefiData) || null;
   const isEdit = activity !== null && activity.id !== 0 && activity.status !== ActivityStatus.DRAFT;
+  const isUserObservator = user?.type === UserType.OBSERVATOR;
 
   const errorSteps = React.useMemo(() => {
     const fieldStep2 = activity?.content.filter((d) => d.value !== ''); // if value is empty in step 2
@@ -86,23 +91,33 @@ const DefiStep4 = () => {
                   {"Modifier à l'étape précédente"}
                 </Button>
               </Link>
-              <Button variant="outlined" color="primary" onClick={onPublish}>
+              <Button variant="outlined" color="primary" onClick={onPublish} disabled={isUserObservator}>
                 Enregistrer les changements
               </Button>
             </div>
           ) : (
-            <div style={{ width: '100%', textAlign: 'right', margin: '1rem 0' }}>
+            <>
               {!isValid && (
                 <p>
                   <b>Avant de publier votre présentation, il faut corriger les étapes incomplètes, marquées en orange.</b>
                 </p>
               )}
               <div style={{ width: '100%', textAlign: 'right', margin: '1rem 0' }}>
-                <Button variant="outlined" color="primary" onClick={onPublish} disabled={!isValid}>
-                  Publier
-                </Button>
+                {isUserObservator ? (
+                  <Tooltip title="Action non autorisée" arrow>
+                    <span>
+                      <Button variant="outlined" color="primary" onClick={onPublish} disabled>
+                        Publier
+                      </Button>
+                    </span>
+                  </Tooltip>
+                ) : (
+                  <Button variant="outlined" color="primary" onClick={onPublish} disabled={!isValid}>
+                    Publier
+                  </Button>
+                )}
               </div>
-            </div>
+            </>
           )}
 
           <span className={classNames('text text--small text--success', { 'text text--small text--warning': !isValid && errorSteps.includes(0) })}>

--- a/src/pages/lancer-un-defi/ecologique/4.tsx
+++ b/src/pages/lancer-un-defi/ecologique/4.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import Backdrop from '@mui/material/Backdrop';
 import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
+import { Tooltip } from '@mui/material';
 
 import { isDefi } from 'src/activity-types/anyActivity';
 import { isEco, getDefi, ECO_ACTIONS, DEFI } from 'src/activity-types/defi.constants';
@@ -17,15 +18,19 @@ import { ContentView } from 'src/components/activities/content/ContentView';
 import { getErrorSteps } from 'src/components/activities/defiEcologieChecks';
 import { EditButton } from 'src/components/buttons/EditButton';
 import { ActivityContext } from 'src/contexts/activityContext';
+import { UserContext } from 'src/contexts/userContext';
 import { ActivityStatus } from 'types/activity.type';
+import { UserType } from 'types/user.type';
 
 const DefiEcoStep4 = () => {
   const router = useRouter();
   const { activity, save } = React.useContext(ActivityContext);
+  const { user } = React.useContext(UserContext);
   const [isLoading, setIsLoading] = React.useState(false);
 
   const data = (activity?.data as EcoDefiData) || null;
   const isEdit = activity !== null && activity.id !== 0 && activity.status !== ActivityStatus.DRAFT;
+  const isUserObservator = user?.type === UserType.OBSERVATOR;
 
   const errorSteps = React.useMemo(() => {
     const fieldStep2 = activity?.content.filter((d) => d.value !== ''); // if value is empty in step 2
@@ -84,23 +89,33 @@ const DefiEcoStep4 = () => {
                   {"Modifier à l'étape précédente"}
                 </Button>
               </Link>
-              <Button variant="outlined" color="primary" onClick={onPublish}>
+              <Button variant="outlined" color="primary" onClick={onPublish} disabled={isUserObservator}>
                 Enregistrer les changements
               </Button>
             </div>
           ) : (
-            <div style={{ width: '100%', textAlign: 'right', margin: '1rem 0' }}>
+            <>
               {!isValid && (
                 <p>
                   <b>Avant de publier votre présentation, il faut corriger les étapes incomplètes, marquées en orange.</b>
                 </p>
               )}
               <div style={{ width: '100%', textAlign: 'right', margin: '1rem 0' }}>
-                <Button variant="outlined" color="primary" onClick={onPublish} disabled={!isValid}>
-                  Publier
-                </Button>
+                {isUserObservator ? (
+                  <Tooltip title="Action non autorisée" arrow>
+                    <span>
+                      <Button variant="outlined" color="primary" onClick={onPublish} disabled>
+                        Publier
+                      </Button>
+                    </span>
+                  </Tooltip>
+                ) : (
+                  <Button variant="outlined" color="primary" onClick={onPublish} disabled={!isValid}>
+                    Publier
+                  </Button>
+                )}
               </div>
-            </div>
+            </>
           )}
 
           <span className={classNames('text text--small text--success', { 'text text--small text--warning': !isValid && errorSteps.includes(0) })}>

--- a/src/pages/lancer-un-defi/ecologique/4.tsx
+++ b/src/pages/lancer-un-defi/ecologique/4.tsx
@@ -104,7 +104,7 @@ const DefiEcoStep4 = () => {
                 {isUserObservator ? (
                   <Tooltip title="Action non autorisée" arrow>
                     <span>
-                      <Button variant="outlined" color="primary" onClick={onPublish} disabled>
+                      <Button variant="outlined" color="primary" disabled>
                         Publier
                       </Button>
                     </span>

--- a/src/pages/lancer-un-defi/linguistique/5.tsx
+++ b/src/pages/lancer-un-defi/linguistique/5.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import Backdrop from '@mui/material/Backdrop';
 import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
+import { Tooltip } from '@mui/material';
 
 import { isDefi } from 'src/activity-types/anyActivity';
 import { isLanguage, getDefi, getLanguageObject, DEFI } from 'src/activity-types/defi.constants';
@@ -17,16 +18,20 @@ import { ContentView } from 'src/components/activities/content/ContentView';
 import { getErrorSteps } from 'src/components/activities/defiLanguageChecks';
 import { EditButton } from 'src/components/buttons/EditButton';
 import { ActivityContext } from 'src/contexts/activityContext';
+import { UserContext } from 'src/contexts/userContext';
 import { ActivityStatus } from 'types/activity.type';
+import { UserType } from 'types/user.type';
 
 const DefiStep5 = () => {
   const router = useRouter();
   const { activity, save } = React.useContext(ActivityContext);
+  const { user } = React.useContext(UserContext);
   const [isLoading, setIsLoading] = React.useState(false);
 
   const data = (activity?.data as LanguageDefiData) || null;
   const explanationContentIndex = Math.max(data?.explanationContentIndex ?? 0, 0);
   const isEdit = activity !== null && activity.id !== 0 && activity.status !== ActivityStatus.DRAFT;
+  const isUserObservator = user?.type === UserType.OBSERVATOR;
 
   const errorSteps = React.useMemo(() => {
     const fieldStep3 = activity?.content.filter((d) => d.value !== ''); // if value is empty in step 3
@@ -91,23 +96,33 @@ const DefiStep5 = () => {
                   {"Modifier à l'étape précédente"}
                 </Button>
               </Link>
-              <Button variant="outlined" color="primary" onClick={onPublish}>
+              <Button variant="outlined" color="primary" onClick={onPublish} disabled={isUserObservator}>
                 Enregistrer les changements
               </Button>
             </div>
           ) : (
-            <div style={{ width: '100%', textAlign: 'right', margin: '1rem 0' }}>
+            <>
               {!isValid && (
                 <p>
                   <b>Avant de publier votre présentation, il faut corriger les étapes incomplètes, marquées en orange.</b>
                 </p>
               )}
               <div style={{ width: '100%', textAlign: 'right', margin: '1rem 0' }}>
-                <Button variant="outlined" color="primary" onClick={onPublish} disabled={!isValid}>
-                  Publier
-                </Button>
+                {isUserObservator ? (
+                  <Tooltip title="Action non autorisée" arrow>
+                    <span>
+                      <Button variant="outlined" color="primary" onClick={onPublish} disabled>
+                        Publier
+                      </Button>
+                    </span>
+                  </Tooltip>
+                ) : (
+                  <Button variant="outlined" color="primary" onClick={onPublish} disabled={!isValid}>
+                    Publier
+                  </Button>
+                )}
               </div>
-            </div>
+            </>
           )}
 
           <div className={classNames('preview-block', { 'preview-block--warning': !isValid && errorSteps.includes(0) })}>

--- a/src/pages/lancer-un-defi/linguistique/5.tsx
+++ b/src/pages/lancer-un-defi/linguistique/5.tsx
@@ -111,7 +111,7 @@ const DefiStep5 = () => {
                 {isUserObservator ? (
                   <Tooltip title="Action non autorisée" arrow>
                     <span>
-                      <Button variant="outlined" color="primary" onClick={onPublish} disabled>
+                      <Button variant="outlined" color="primary" disabled>
                         Publier
                       </Button>
                     </span>

--- a/src/pages/mascotte/5.tsx
+++ b/src/pages/mascotte/5.tsx
@@ -4,7 +4,7 @@ import { useQueryClient } from 'react-query';
 import React from 'react';
 
 import CircularProgress from '@mui/material/CircularProgress';
-import { Button, Grid, Backdrop, Box } from '@mui/material';
+import { Button, Grid, Backdrop, Box, Tooltip } from '@mui/material';
 
 import { isMascotte } from 'src/activity-types/anyActivity';
 import { getMascotteContent } from 'src/activity-types/mascotte.constants';
@@ -23,6 +23,7 @@ import { useCurrencies } from 'src/services/useCurrencies';
 import { useLanguages } from 'src/services/useLanguages';
 import { ActivityStatus } from 'types/activity.type';
 import type { User } from 'types/user.type';
+import { UserType } from 'types/user.type';
 
 const MascotteStep4 = () => {
   const router = useRouter();
@@ -35,6 +36,7 @@ const MascotteStep4 = () => {
   const [isLoading, setIsLoading] = React.useState(false);
 
   const isEdit = activity !== null && activity.id !== 0 && activity.status !== ActivityStatus.DRAFT;
+  const isUserObservator = user?.type === UserType.OBSERVATOR;
   const data = (activity?.data as MascotteData) || null;
   const errorSteps = React.useMemo(() => {
     if (data !== null) {
@@ -157,16 +159,33 @@ const MascotteStep4 = () => {
             )}
             {isEdit ? (
               <div style={{ width: '100%', textAlign: 'right', margin: '1rem 0' }}>
-                <Button variant="outlined" color="primary" onClick={onPublish}>
+                <Button variant="outlined" color="primary" onClick={onPublish} disabled={isUserObservator}>
                   Enregistrer les changements
                 </Button>
               </div>
             ) : (
-              <div style={{ width: '100%', textAlign: 'right', margin: '1rem 0' }}>
-                <Button variant="outlined" color="primary" onClick={onPublish} disabled={!isValid}>
-                  Publier
-                </Button>
-              </div>
+              <>
+                {!isValid && (
+                  <p>
+                    <b>Avant de publier votre présentation, il faut corriger les étapes incomplètes, marquées en orange.</b>
+                  </p>
+                )}
+                <div style={{ width: '100%', textAlign: 'right', margin: '1rem 0' }}>
+                  {isUserObservator ? (
+                    <Tooltip title="Action non autorisée" arrow>
+                      <span>
+                        <Button variant="outlined" color="primary" onClick={onPublish} disabled>
+                          Publier
+                        </Button>
+                      </span>
+                    </Tooltip>
+                  ) : (
+                    <Button variant="outlined" color="primary" onClick={onPublish} disabled={!isValid}>
+                      Publier
+                    </Button>
+                  )}
+                </div>
+              </>
             )}
             <div className={classNames('preview-block', { 'preview-block--warning': !isValid && errorSteps.includes(0) })}>
               <EditButton

--- a/src/pages/mascotte/5.tsx
+++ b/src/pages/mascotte/5.tsx
@@ -174,7 +174,7 @@ const MascotteStep4 = () => {
                   {isUserObservator ? (
                     <Tooltip title="Action non autorisée" arrow>
                       <span>
-                        <Button variant="outlined" color="primary" onClick={onPublish} disabled>
+                        <Button variant="outlined" color="primary" disabled>
                           Publier
                         </Button>
                       </span>

--- a/src/pages/reagir-a-une-activite/3.tsx
+++ b/src/pages/reagir-a-une-activite/3.tsx
@@ -85,7 +85,7 @@ const ReactionStep3 = () => {
               {isUserObservator ? (
                 <Tooltip title="Action non autorisée" arrow>
                   <span>
-                    <Button variant="outlined" color="primary" onClick={onPublish} disabled>
+                    <Button variant="outlined" color="primary" disabled>
                       Publier
                     </Button>
                   </span>

--- a/src/pages/reagir-a-une-activite/3.tsx
+++ b/src/pages/reagir-a-une-activite/3.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import Backdrop from '@mui/material/Backdrop';
 import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
+import { Tooltip } from '@mui/material';
 
 import { isReaction } from 'src/activity-types/anyActivity';
 import { Base } from 'src/components/Base';
@@ -16,16 +17,20 @@ import { ContentView } from 'src/components/activities/content/ContentView';
 import { REACTIONS } from 'src/components/activities/utils';
 import { EditButton } from 'src/components/buttons/EditButton';
 import { ActivityContext } from 'src/contexts/activityContext';
+import { UserContext } from 'src/contexts/userContext';
 import { useActivity } from 'src/services/useActivity';
 import { ActivityStatus } from 'types/activity.type';
+import { UserType } from 'types/user.type';
 
 const ReactionStep3 = () => {
   const router = useRouter();
   const { activity, save } = React.useContext(ActivityContext);
+  const { user } = React.useContext(UserContext);
   const { activity: responseActivity } = useActivity(activity?.responseActivityId ?? -1);
   const [isLoading, setIsLoading] = React.useState(false);
 
   const isEdit = activity !== null && activity.id !== 0 && activity.status !== ActivityStatus.DRAFT;
+  const isUserObservator = user?.type === UserType.OBSERVATOR;
 
   React.useEffect(() => {
     if (activity === null && !('activity-id' in router.query) && !sessionStorage.getItem('activity')) {
@@ -71,15 +76,25 @@ const ReactionStep3 = () => {
                   {"Modifier à l'étape précédente"}
                 </Button>
               </Link>
-              <Button variant="outlined" color="primary" onClick={onPublish}>
+              <Button variant="outlined" color="primary" onClick={onPublish} disabled={isUserObservator}>
                 Enregistrer les changements
               </Button>
             </div>
           ) : (
             <div style={{ width: '100%', textAlign: 'right', margin: '1rem 0' }}>
-              <Button variant="outlined" color="primary" onClick={onPublish}>
-                Publier
-              </Button>
+              {isUserObservator ? (
+                <Tooltip title="Action non autorisée" arrow>
+                  <span>
+                    <Button variant="outlined" color="primary" onClick={onPublish} disabled>
+                      Publier
+                    </Button>
+                  </span>
+                </Tooltip>
+              ) : (
+                <Button variant="outlined" color="primary" onClick={onPublish}>
+                  Publier
+                </Button>
+              )}
             </div>
           )}
 

--- a/src/pages/realiser-un-reportage/3.tsx
+++ b/src/pages/realiser-un-reportage/3.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import Backdrop from '@mui/material/Backdrop';
 import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
+import { Tooltip } from '@mui/material';
 
 import { isReportage } from 'src/activity-types/anyActivity';
 import { getReportage } from 'src/activity-types/reportage.constants';
@@ -17,14 +18,18 @@ import { ContentView } from 'src/components/activities/content/ContentView';
 import { getErrorSteps } from 'src/components/activities/reportageChecks';
 import { EditButton } from 'src/components/buttons/EditButton';
 import { ActivityContext } from 'src/contexts/activityContext';
+import { UserContext } from 'src/contexts/userContext';
 import { ActivityStatus } from 'types/activity.type';
+import { UserType } from 'types/user.type';
 
 const ReportageStep3 = () => {
   const router = useRouter();
   const { activity, save } = React.useContext(ActivityContext);
+  const { user } = React.useContext(UserContext);
   const [isLoading, setIsLoading] = React.useState(false);
 
   const isEdit = activity != null && activity.id !== 0 && activity.status !== ActivityStatus.DRAFT;
+  const isUserObservator = user?.type === UserType.OBSERVATOR;
   const data = (activity?.data as ReportageData) || null;
 
   const errorSteps = React.useMemo(() => {
@@ -94,15 +99,25 @@ const ReportageStep3 = () => {
                   {"Modifier à l'étape précédente"}
                 </Button>
               </Link>
-              <Button variant="outlined" color="primary" onClick={onPublish}>
+              <Button variant="outlined" color="primary" onClick={onPublish} disabled={isUserObservator}>
                 Enregistrer les changements
               </Button>
             </div>
           ) : (
             <div style={{ width: '100%', textAlign: 'right', margin: '1rem 0' }}>
-              <Button variant="outlined" color="primary" onClick={onPublish} disabled={!isValid}>
-                Publier
-              </Button>
+              {isUserObservator ? (
+                <Tooltip title="Action non autorisée" arrow>
+                  <span>
+                    <Button variant="outlined" color="primary" onClick={onPublish} disabled>
+                      Publier
+                    </Button>
+                  </span>
+                </Tooltip>
+              ) : (
+                <Button variant="outlined" color="primary" onClick={onPublish} disabled={!isValid}>
+                  Publier
+                </Button>
+              )}
             </div>
           )}
 

--- a/src/pages/realiser-un-reportage/3.tsx
+++ b/src/pages/realiser-un-reportage/3.tsx
@@ -108,7 +108,7 @@ const ReportageStep3 = () => {
               {isUserObservator ? (
                 <Tooltip title="Action non autorisée" arrow>
                   <span>
-                    <Button variant="outlined" color="primary" onClick={onPublish} disabled>
+                    <Button variant="outlined" color="primary" disabled>
                       Publier
                     </Button>
                   </span>

--- a/src/pages/se-presenter/thematique/4.tsx
+++ b/src/pages/se-presenter/thematique/4.tsx
@@ -83,7 +83,7 @@ const PresentationStep4 = () => {
               {isUserObservator ? (
                 <Tooltip title="Action non autorisée" arrow>
                   <span>
-                    <Button variant="outlined" color="primary" onClick={onPublish} disabled>
+                    <Button variant="outlined" color="primary" disabled>
                       Publier
                     </Button>
                   </span>

--- a/src/pages/se-presenter/thematique/4.tsx
+++ b/src/pages/se-presenter/thematique/4.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import Backdrop from '@mui/material/Backdrop';
 import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
+import { Tooltip } from '@mui/material';
 
 import { isPresentation } from 'src/activity-types/anyActivity';
 import { PRESENTATION_THEMATIQUE } from 'src/activity-types/presentation.constants';
@@ -17,14 +18,18 @@ import { ContentView } from 'src/components/activities/content/ContentView';
 import { REACTIONS } from 'src/components/activities/utils';
 import { EditButton } from 'src/components/buttons/EditButton';
 import { ActivityContext } from 'src/contexts/activityContext';
+import { UserContext } from 'src/contexts/userContext';
 import { useActivity } from 'src/services/useActivity';
 import { ActivityStatus } from 'types/activity.type';
+import { UserType } from 'types/user.type';
 
 const PresentationStep4 = () => {
   const router = useRouter();
   const { activity, save } = React.useContext(ActivityContext);
+  const { user } = React.useContext(UserContext);
   const { activity: responseActivity } = useActivity(activity?.responseActivityId ?? -1);
   const [isLoading, setIsLoading] = React.useState(false);
+  const isUserObservator = user?.type === UserType.OBSERVATOR;
 
   const data = activity?.data || null;
   const isEdit = activity !== null && activity.id !== 0 && activity.status !== ActivityStatus.DRAFT;
@@ -69,15 +74,25 @@ const PresentationStep4 = () => {
                   {"Modifier à l'étape précédente"}
                 </Button>
               </Link>
-              <Button variant="outlined" color="primary" onClick={onPublish}>
+              <Button variant="outlined" color="primary" onClick={onPublish} disabled={isUserObservator}>
                 Enregistrer les changements
               </Button>
             </div>
           ) : (
             <div style={{ width: '100%', textAlign: 'right', margin: '1rem 0' }}>
-              <Button variant="outlined" color="primary" onClick={onPublish}>
-                Publier
-              </Button>
+              {isUserObservator ? (
+                <Tooltip title="Action non autorisée" arrow>
+                  <span>
+                    <Button variant="outlined" color="primary" onClick={onPublish} disabled>
+                      Publier
+                    </Button>
+                  </span>
+                </Tooltip>
+              ) : (
+                <Button variant="outlined" color="primary" onClick={onPublish}>
+                  Publier
+                </Button>
+              )}
             </div>
           )}
 

--- a/src/pages/symbole/3.tsx
+++ b/src/pages/symbole/3.tsx
@@ -102,7 +102,7 @@ const SymbolStep3 = () => {
                 {isUserObservator ? (
                   <Tooltip title="Action non autorisée" arrow>
                     <span>
-                      <Button variant="outlined" color="primary" onClick={onPublish} disabled>
+                      <Button variant="outlined" color="primary" disabled>
                         Publier
                       </Button>
                     </span>

--- a/src/pages/symbole/3.tsx
+++ b/src/pages/symbole/3.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import Backdrop from '@mui/material/Backdrop';
 import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
+import { Tooltip } from '@mui/material';
 
 import { isSymbol } from 'src/activity-types/anyActivity';
 import { getSymbol } from 'src/activity-types/symbol.constants';
@@ -16,14 +17,19 @@ import { Steps } from 'src/components/Steps';
 import { ContentView } from 'src/components/activities/content/ContentView';
 import { EditButton } from 'src/components/buttons/EditButton';
 import { ActivityContext } from 'src/contexts/activityContext';
+import { UserContext } from 'src/contexts/userContext';
 import { ActivityStatus } from 'types/activity.type';
+import { UserType } from 'types/user.type';
 
 const SymbolStep3 = () => {
   const router = useRouter();
   const { activity, save } = React.useContext(ActivityContext);
+  const { user } = React.useContext(UserContext);
   const [isLoading, setIsLoading] = React.useState(false);
 
   const isEdit = activity !== null && activity.id !== 0 && activity.status !== ActivityStatus.DRAFT;
+  const isUserObservator = user?.type === UserType.OBSERVATOR;
+
   const data = (activity?.data as SymbolData) || null;
 
   React.useEffect(() => {
@@ -81,16 +87,33 @@ const SymbolStep3 = () => {
                   {"Modifier à l'étape précédente"}
                 </Button>
               </Link>
-              <Button variant="outlined" color="primary" onClick={onPublish}>
+              <Button variant="outlined" color="primary" onClick={onPublish} disabled={isUserObservator}>
                 Enregistrer les changements
               </Button>
             </div>
           ) : (
-            <div style={{ width: '100%', textAlign: 'right', margin: '1rem 0' }}>
-              <Button variant="outlined" color="primary" onClick={onPublish} disabled={!isValid}>
-                Publier
-              </Button>
-            </div>
+            <>
+              {!isValid && (
+                <p>
+                  <b>Avant de publier votre présentation, il faut corriger les étapes incomplètes, marquées en orange.</b>
+                </p>
+              )}
+              <div style={{ width: '100%', textAlign: 'right', margin: '1rem 0' }}>
+                {isUserObservator ? (
+                  <Tooltip title="Action non autorisée" arrow>
+                    <span>
+                      <Button variant="outlined" color="primary" onClick={onPublish} disabled>
+                        Publier
+                      </Button>
+                    </span>
+                  </Tooltip>
+                ) : (
+                  <Button variant="outlined" color="primary" onClick={onPublish} disabled={!isValid}>
+                    Publier
+                  </Button>
+                )}
+              </div>
+            </>
           )}
 
           <span className={'text text--small text--success'}>Thème</span>


### PR DESCRIPTION
### Motivation

Make sure that observers cannot publish activities but can play (without affecting the statistics) at mimic.

### Changes

All the files for publish a activity : 
server/controllers/game.ts
src/pages/creer-un-jeu/mimique/4.tsx
src/pages/creer-une-enigme/4.tsx
src/pages/indice-culturel/3.tsx
src/pages/lancer-un-defi/culinaire/4.tsx
src/pages/lancer-un-defi/ecologique/4.tsx
src/pages/lancer-un-defi/linguistique/5.tsx
src/pages/mascotte/5.tsx
src/pages/reagir-a-une-activite/3.tsx
src/pages/realiser-un-reportage/3.tsx
src/pages/se-presenter/thematique/4.tsx
src/pages/symbole/3.tsx

### Test

Go to any activity and when it comes the time to publish a message will indicate it is not possible : 
![1Village - Google Chrome 2022-02-10 10-43-32 (1)](https://user-images.githubusercontent.com/75479164/153381349-7df85f68-3e0b-4371-b1e1-ee9a165c0452.gif)

