### PR TITLE
reaction arrow color fix

### DIFF
--- a/src/components/activities/List.tsx
+++ b/src/components/activities/List.tsx
@@ -94,7 +94,16 @@ export const Activities = ({ activities, noButtons = false, withLinks = false, o
                       <span className="text text--small text--primary" style={{ fontSize: '0.8rem' }}>
                         En réaction à
                       </span>
-                      <ReactionIcon style={{ width: '4rem', height: '4rem', cursor: 'pointer', position: 'relative', display: 'inline-block' }} />
+                      <ReactionIcon
+                        style={{
+                          fill: primaryColor,
+                          width: '4rem',
+                          height: '4rem',
+                          cursor: 'pointer',
+                          position: 'relative',
+                          display: 'inline-block',
+                        }}
+                      />
                     </Button>
                   </div>
                 </div>


### PR DESCRIPTION
### Motivation

In the Phase 2 activity feed, the arrow used to indicate reaction activities is black.
![image](https://user-images.githubusercontent.com/61083815/153586257-f2bfab57-bd9e-4689-b1fb-b00162b54c9b.png)

### Changes

Change the icon color in List.tsx

### Test

1.Create an activity.
2. React to it.
3. The arrow color activity feed is purple.