### PR TITLE
fix-make feed images clickable

### DIFF
--- a/src/components/activities/ActivityCard/DefiCard.tsx
+++ b/src/components/activities/ActivityCard/DefiCard.tsx
@@ -43,9 +43,12 @@ export const DefiCard = ({ activity, isSelf, noButtons, isDraft, showEditButtons
               width: '100%',
               backgroundColor: bgPage,
               position: 'relative',
+              cursor: 'pointer',
             }}
           >
-            <Image layout="fill" objectFit="contain" src={firstImage} unoptimized />
+            <Link href={`/activite/${activity.id}`} passHref>
+              <Image layout="fill" objectFit="contain" src={firstImage} unoptimized />
+            </Link>
           </div>
         </div>
       )}

--- a/src/components/activities/ActivityCard/EnigmeCard.tsx
+++ b/src/components/activities/ActivityCard/EnigmeCard.tsx
@@ -44,7 +44,9 @@ export const EnigmeCard = ({ activity, isSelf, noButtons, isDraft, showEditButto
               position: 'relative',
             }}
           >
-            <Image layout="fill" objectFit="contain" src={firstImage.value} unoptimized />
+            <Link href={`/activite/${activity.id}`} passHref>
+              <Image layout="fill" objectFit="contain" src={firstImage.value} unoptimized />
+            </Link>
           </div>
         </div>
       )}

--- a/src/components/activities/ActivityCard/FreeContentCard.tsx
+++ b/src/components/activities/ActivityCard/FreeContentCard.tsx
@@ -31,9 +31,12 @@ export const FreeContentCard = ({ activity, isSelf, noButtons, isDraft, showEdit
               width: '100%',
               backgroundColor: bgPage,
               position: 'relative',
+              cursor: 'pointer',
             }}
           >
-            <Image layout="fill" objectFit="contain" src={firstImage} unoptimized />
+            <Link href={`/activite/${activity.id}`} passHref>
+              <Image layout="fill" objectFit="contain" src={firstImage} unoptimized />
+            </Link>
           </div>
         </div>
       )}

--- a/src/components/activities/ActivityCard/IndiceCard.tsx
+++ b/src/components/activities/ActivityCard/IndiceCard.tsx
@@ -36,9 +36,12 @@ export const IndiceCard = ({ activity, isSelf, noButtons, isDraft, showEditButto
               width: '100%',
               backgroundColor: bgPage,
               position: 'relative',
+              cursor: 'pointer',
             }}
           >
-            <Image layout="fill" objectFit="contain" src={firstImage.value} unoptimized />
+            <Link href={`/activite/${activity.id}`} passHref>
+              <Image layout="fill" objectFit="contain" src={firstImage.value} unoptimized />
+            </Link>
           </div>
         </div>
       )}

--- a/src/components/activities/ActivityCard/MimicCard.tsx
+++ b/src/components/activities/ActivityCard/MimicCard.tsx
@@ -53,10 +53,12 @@ export const MimicCard = ({ activity, isSelf, noButtons, isDraft, showEditButton
               width: '100%',
               backgroundColor: bgPage,
               position: 'relative',
-              pointerEvents: 'none', //Disable click on video
+              cursor: 'pointer',
             }}
           >
-            <ReactPlayer width="100%" height="100%" light url={randomVideoLink} style={{ backgroundColor: 'black' }} />
+            <Link href="/creer-un-jeu/mimique" passHref>
+              <ReactPlayer width="100%" height="100%" light url={randomVideoLink} style={{ backgroundColor: 'black' }} />
+            </Link>
           </div>
         </div>
       )}

--- a/src/components/activities/ActivityCard/PresentationCard.tsx
+++ b/src/components/activities/ActivityCard/PresentationCard.tsx
@@ -34,9 +34,12 @@ export const PresentationCard = ({ activity, isSelf, noButtons, isDraft, showEdi
               width: '100%',
               backgroundColor: bgPage,
               position: 'relative',
+              cursor: 'pointer',
             }}
           >
-            <Image layout="fill" objectFit="contain" src={firstImage.value} unoptimized />
+            <Link href={`/activite/${activity.id}`} passHref>
+              <Image layout="fill" objectFit="contain" src={firstImage.value} unoptimized />
+            </Link>
           </div>
         </div>
       )}

--- a/src/components/activities/ActivityCard/ReactionCard.tsx
+++ b/src/components/activities/ActivityCard/ReactionCard.tsx
@@ -33,9 +33,12 @@ export const ReactionCard = ({ activity, isSelf, noButtons, isDraft, showEditBut
               width: '100%',
               backgroundColor: bgPage,
               position: 'relative',
+              cursor: 'pointer',
             }}
           >
-            <Image layout="fill" objectFit="contain" src={firstImage.value} unoptimized />
+            <Link href={`/activite/${activity.id}`} passHref>
+              <Image layout="fill" objectFit="contain" src={firstImage.value} unoptimized />
+            </Link>
           </div>
         </div>
       )}

--- a/src/components/activities/ActivityCard/ReportageCard.tsx
+++ b/src/components/activities/ActivityCard/ReportageCard.tsx
@@ -39,9 +39,12 @@ export const ReportageCard = ({ activity, isSelf, noButtons, isDraft, showEditBu
               width: '100%',
               backgroundColor: bgPage,
               position: 'relative',
+              cursor: 'pointer',
             }}
           >
-            <Image layout="fill" objectFit="contain" src={firstImage.value} unoptimized />
+            <Link href={`/activite/${activity.id}`} passHref>
+              <Image layout="fill" objectFit="contain" src={firstImage.value} unoptimized />
+            </Link>
           </div>
         </div>
       ) : firstVideo ? (
@@ -52,10 +55,12 @@ export const ReportageCard = ({ activity, isSelf, noButtons, isDraft, showEditBu
               width: '100%',
               backgroundColor: bgPage,
               position: 'relative',
-              pointerEvents: 'none', //Disable click on video
+              cursor: 'pointer',
             }}
           >
-            <ReactPlayer width="100%" height="100%" url={firstVideo.value} light />
+            <Link href={`/activite/${activity.id}`} passHref>
+              <ReactPlayer width="100%" height="100%" url={firstVideo.value} light />
+            </Link>
           </div>
         </div>
       ) : (

--- a/src/components/activities/ActivityCard/SymbolCard.tsx
+++ b/src/components/activities/ActivityCard/SymbolCard.tsx
@@ -36,9 +36,12 @@ export const SymbolCard = ({ activity, isSelf, noButtons, isDraft, showEditButto
               width: '100%',
               backgroundColor: bgPage,
               position: 'relative',
+              cursor: 'pointer',
             }}
           >
-            <Image layout="fill" objectFit="contain" src={firstImage.value} unoptimized />
+            <Link href={`/activite/${activity.id}`} passHref>
+              <Image layout="fill" objectFit="contain" src={firstImage.value} unoptimized />
+            </Link>
           </div>
         </div>
       )}


### PR DESCRIPTION
### Motivation

When an activity in the feed has a front page image, it would be nicer to be able to click on it to go to the activity details.

### Changes

Adding activity's link to all card activities that contain an image.

### Test

Click on an activity image in the homepage.
