### PR TITLE
fix-display flags in Navigation as moderator & observer

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -204,8 +204,8 @@ export const Navigation = (): JSX.Element => {
                 isMistery={
                   !village ||
                   !user ||
-                  (selectedPhase === 1 && user.country.isoCode.toUpperCase() !== country.isoCode && !isObservator) ||
-                  (user.firstLogin < 2 && user.country.isoCode.toUpperCase() !== country.isoCode && !isObservator)
+                  (selectedPhase === 1 && user.country.isoCode.toUpperCase() !== country.isoCode && (!isModerateur || isObservator)) ||
+                  (user.firstLogin < 2 && user.country.isoCode.toUpperCase() !== country.isoCode && (!isModerateur || isObservator))
                 }
               ></Flag>
             ))}


### PR DESCRIPTION
### Motivation

When we're connected as admin, the flags in the left Navigation are not displayed correctly. 

https://user-images.githubusercontent.com/61083815/171000370-2175b016-1b63-4355-8fd0-4278def48e22.mp4


### Changes

src/components/Navigation.tsx

### Test

Connect as admin, both flags should are available in all three phases. Connect as either observer or teacher, only one flag is displayed in phase 1 and both are displayed in phase 2 and 3. 
