### PR TITLE
[TypeORM] Add typeorm migrations

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,16 +16,36 @@ services:
       - ./src:/app/src
       - ./server:/app/server
       - ./types:/app/types
+    depends_on:
+      migration:
+        condition: service_completed_successfully
+      mysql:
+        condition: service_healthy
+  migration:
+    build:
+      context: ./
+      dockerfile: Dockerfile.development
+    links:
+      - mysql
+    env_file:
+      - .env
+    depends_on:
+      mysql:
+        condition: service_healthy
+    command: [ "yarn", "run", "migration:run-dev"]
   mysql:
     image: mysql:8
     environment:
       - MYSQL_ROOT_PASSWORD=my-secret-pw
+    healthcheck:
+      test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost"]
+      timeout: 20s
+      retries: 10
     ports:
       - '3306:3306'
       - '33060:33060'
     volumes:
       - ./.mysql-data:/var/lib/mysql
-
   minio:
     image: minio/minio
     ports:

--- a/package.json
+++ b/package.json
@@ -15,10 +15,13 @@
     "typescript:server": "yarn tsc --project server/tsconfig.json --noEmit",
     "typescript": "yarn tsc -p . && yarn typescript:server",
     "test": "yarn jest --runInBand",
-    "start-dev": "yarn build:server && node dist/server/start.js",
-    "start": "NODE_ENV=production node dist/server/start.js",
+    "start-dev": "rm -rf dist && yarn build:server && node dist/server/start.js",
+    "start": "yarn migration:run && NODE_ENV=production node dist/server/start.js",
     "dev": "yarn nodemon",
-    "dev-staging": "NODE_USE_STAGING=true yarn nodemon"
+    "dev-staging": "NODE_USE_STAGING=true yarn nodemon",
+    "migration:create": "cd server && mkdir migrations && cd migrations && yarn typeorm migration:create",
+    "migration:run": "yarn typeorm migration:run -d dist/server/utils/data-source.js",
+    "migration:run-dev": "rm -rf dist && yarn build:server && yarn typeorm migration:run -d dist/server/utils/data-source.js"
   },
   "jest": {
     "testEnvironment": "node",

--- a/server/utils/data-source.ts
+++ b/server/utils/data-source.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import type { DataSourceOptions } from 'typeorm';
 import { DataSource } from 'typeorm';
+import 'dotenv/config';
 
 const DEFAULT_TYPE = 'mysql' as const;
 const DEFAULT_HOST = 'localhost';
@@ -35,8 +36,9 @@ function getAppDataSource(): DataSource {
     charset: 'utf8mb4_unicode_ci',
     logging: process.env.NODE_ENV !== 'production',
     entities: [path.join(__dirname, '../entities/*.js')],
+    migrations: [path.join(__dirname, '../migrations/*.js')],
     subscribers: [],
-    synchronize: true,
+    synchronize: false,
     ...connectionOptions,
   });
 }


### PR DESCRIPTION
### Motivation

Add typeorm migrations.

### Changes

- Update package-json with new script:
  - `yarn migration:create myMigration`: will create a new migration.
  - `yarn migration:run`: will run the migrations.
  - `yarn migration:run-dev`: will compile the typescript files and run the migrations.
- Add migration job in docker-compose for local dev: migrations will run at every start of `docker-compose up`.
- Add migration job before start script for production.
- Add migrations folder to data-source and set `synchronize` to false. We use migrations now!

### Test

 - Create a migration locally.
 - Run docker-compose -> the migration should run.