### PR TITLE
Fix migrations when DB does not exist

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "start": "yarn migration:run && NODE_ENV=production node dist/server/start.js",
     "dev": "yarn nodemon",
     "dev-staging": "NODE_USE_STAGING=true yarn nodemon",
-    "migration:create": "cd server && mkdir migrations && cd migrations && yarn typeorm migration:create",
+    "migration:create": "cd server && mkdir -p migrations && cd migrations && yarn typeorm migration:create",
     "migration:run": "yarn typeorm migration:run -d dist/server/utils/data-source.js",
-    "migration:run-dev": "rm -rf dist && yarn build:server && yarn typeorm migration:run -d dist/server/utils/data-source.js"
+    "migration:run-dev": "rm -rf dist && yarn build:server && yarn typeorm migration:run -d dist/server/utils/data-source.js || true"
   },
   "jest": {
     "testEnvironment": "node",


### PR DESCRIPTION
### Motivation

Fix migrations when DB does not exist.

### Changes

- Use `mkdir` with the `-p` flag to check whether or not the directory already exist.
- Run the migration and add `|| true` in the bash command to always exist with a code 0 even if the migration command fail. This is safe because this command is used locally, not in production.
- Add `createTablesIfNotExist` function to synchronise the database once at startup if the database does not exist. This is a temporary fix. The migrations should create the database and the tables... I'll work on this later.

