### PR TITLE
moduleDirectories in package Json changed

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
       "**/**/*.test.t(s|sx)"
     ],
     "moduleDirectories": [
-      ".",
+      "<rootDir>",
       "types",
       "node_modules"
     ],


### PR DESCRIPTION
### Motivation

Jest test weren't working anymore.

### Changes

Applied the following chances: https://stackoverflow.com/questions/72401004/jest-28-createjestexpect-typeerror-cannot-read-properties-of-undefined-read

package.json jest 
"." => "<rootDir>"

### Test

test if the jest tests work
