### PR TITLE
Fix user controller routes

### DIFF
--- a/server/migrations/1675763051163-CreateClassroomTable.ts
+++ b/server/migrations/1675763051163-CreateClassroomTable.ts
@@ -2,20 +2,20 @@ import type { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class CreateClassroomTable1675763051163 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`CREATE TABLE IF NOT EXISTS "classroom" (
-        "id" int NOT NULL AUTO_INCREMENT,
-        "name" varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-        "avatar" varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-        "delayedDays" int DEFAULT '0',
-        "hasVisibilitySetToClass" tinyint DEFAULT '0',
-        "userId" int DEFAULT NULL,
-        "villageId" int DEFAULT NULL,
-        PRIMARY KEY ("id"),
-        UNIQUE KEY "REL_6f2187911a8faba7c91a83194d" ("userId"),
-        KEY "FK_ce22c442aec315cd3aa13b69210" ("villageId"),
-        CONSTRAINT "FK_6f2187911a8faba7c91a83194d9" FOREIGN KEY ("userId") REFERENCES "user" ("id"),
-        CONSTRAINT "FK_ce22c442aec315cd3aa13b69210" FOREIGN KEY ("villageId") REFERENCES "village" ("id")
-      ) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;`);
+    await queryRunner.query(`CREATE TABLE IF NOT EXISTS classroom (
+      id int NOT NULL AUTO_INCREMENT,
+      \`name\` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+      avatar varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+      delayedDays int DEFAULT '0',
+      hasVisibilitySetToClass tinyint DEFAULT '0',
+      userId int DEFAULT NULL,
+      villageId int DEFAULT NULL,
+      PRIMARY KEY (id),
+      UNIQUE KEY REL_6f2187911a8faba7c91a83194d (userId),
+      KEY FK_ce22c442aec315cd3aa13b69210 (villageId),
+      CONSTRAINT FK_6f2187911a8faba7c91a83194d9 FOREIGN KEY (userId) REFERENCES user (id),
+      CONSTRAINT FK_ce22c442aec315cd3aa13b69210 FOREIGN KEY (villageId) REFERENCES village (id)
+    ) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;`);
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {

--- a/server/migrations/1675763075677-CreateStudentTable.ts
+++ b/server/migrations/1675763075677-CreateStudentTable.ts
@@ -2,17 +2,17 @@ import type { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class CreateStudentTable1675763075677 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`CREATE TABLE IF NOT EXISTS "student" (
-        "id" int NOT NULL AUTO_INCREMENT,
-        "firstname" varchar(100) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-        "lastname" varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
-        "hashedCode" varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
-        "numLinkedAccount" tinyint DEFAULT '0',
-        "classroomId" int DEFAULT NULL,
-        PRIMARY KEY ("id"),
-        KEY "FK_426224f5597213259b1d58fc0f4" ("classroomId"),
-        CONSTRAINT "FK_426224f5597213259b1d58fc0f4" FOREIGN KEY ("classroomId") REFERENCES "classroom" ("id")
-      ) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;`);
+    await queryRunner.query(`CREATE TABLE IF NOT EXISTS student (
+      id int NOT NULL AUTO_INCREMENT,
+      firstname varchar(100) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+      lastname varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+      hashedCode varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+      numLinkedAccount tinyint DEFAULT '0',
+      classroomId int DEFAULT NULL,
+      PRIMARY KEY (id),
+      KEY FK_426224f5597213259b1d58fc0f4 (classroomId),
+      CONSTRAINT FK_426224f5597213259b1d58fc0f4 FOREIGN KEY (classroomId) REFERENCES classroom (id)
+    ) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;`);
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {

--- a/server/migrations/1675763247781-CreateUserStudentTable.ts
+++ b/server/migrations/1675763247781-CreateUserStudentTable.ts
@@ -3,16 +3,16 @@ import type { MigrationInterface, QueryRunner } from 'typeorm';
 export class CreateUserStudentTable1675763247781 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`
-    CREATE TABLE IF NOT EXISTS "user_to_student" (
-        "id" int NOT NULL AUTO_INCREMENT,
-        "userId" int DEFAULT NULL,
-        "studentId" int DEFAULT NULL,
-        PRIMARY KEY ("id"),
-        KEY "FK_c4a67eb239df56e50679e238eec" ("userId"),
-        KEY "FK_39299bddd62684b6bf55a7a8aec" ("studentId"),
-        CONSTRAINT "FK_39299bddd62684b6bf55a7a8aec" FOREIGN KEY ("studentId") REFERENCES "student" ("id"),
-        CONSTRAINT "FK_c4a67eb239df56e50679e238eec" FOREIGN KEY ("userId") REFERENCES "user" ("id")
-      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+    CREATE TABLE IF NOT EXISTS user_to_student (
+      id int NOT NULL AUTO_INCREMENT,
+      userId int DEFAULT NULL,
+      studentId int DEFAULT NULL,
+      PRIMARY KEY (id),
+      KEY FK_c4a67eb239df56e50679e238eec (userId),
+      KEY FK_39299bddd62684b6bf55a7a8aec (studentId),
+      CONSTRAINT FK_39299bddd62684b6bf55a7a8aec FOREIGN KEY (studentId) REFERENCES student (id),
+      CONSTRAINT FK_c4a67eb239df56e50679e238eec FOREIGN KEY (userId) REFERENCES user (id)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
     `);
   }
 

--- a/server/migrations/1675763659256-AlterUserTable.ts
+++ b/server/migrations/1675763659256-AlterUserTable.ts
@@ -16,6 +16,17 @@ export class AlterUserTable1675763659256 implements MigrationInterface {
         length: '100',
         default: '""',
       }),
+      new TableColumn({
+        name: 'language',
+        type: 'varchar',
+        length: '400',
+        default: '""',
+      }),
+      new TableColumn({
+        name: 'hasAcceptedNewsletter',
+        type: 'tinyint',
+        default: '1',
+      }),
     ]);
 
     await queryRunner.addColumn(
@@ -49,7 +60,7 @@ export class AlterUserTable1675763659256 implements MigrationInterface {
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.dropColumns('user', ['firstname', 'lastname']);
+    await queryRunner.dropColumns('user', ['firstname', 'lastname', 'language', 'hasAcceptedNewsletter']);
     // Map the tinyint values to the old enum values
     const mapping = {
       3: '0', // TEACHER = 3


### PR DESCRIPTION
### Motivation

Fix user controller routes: the get user route has the same path as the verify-token route.

### Changes

- Fix SQL in migration files. Quotes `"` are invalid!
- Fix missing user columns in migration file.
- Use a regex for the get user route: set the `:id` parameter to be digits only.
- Verify the query parameters of the verify-token route. 
- Redirect the logged-in user to the root path.

### Test

Test the sign-up locally.
