### PR TITLE
Fix activity card mapping

### DIFF
--- a/src/components/activities/ActivityCard/index.tsx
+++ b/src/components/activities/ActivityCard/index.tsx
@@ -48,6 +48,7 @@ const CardTypeMapper = {
   [ActivityType.STORY]: StoryCard,
   [ActivityType.ANTHEM]: AnthemCard,
   [ActivityType.VERSE_RECORD]: VerseRecordCard,
+  [ActivityType.RE_INVENT_STORY]: StoryCard,
 };
 
 export const ActivityCard = ({


### PR DESCRIPTION
### Motivation

Bug with phase 3 that breaks when uploading re-inventer une histoire because mapping wasn't completed properly (missing re_inventer_une_histoire.

### Changes

index.tsx added ligne 51 (ActivityCard)

### Test

Try going phase 3 after having posted re-inventer une histoire !