### PR TITLE
bugFix %identifiant can't have additionnal letters after it

### DIFF
--- a/src/pages/familles/3.tsx
+++ b/src/pages/familles/3.tsx
@@ -47,7 +47,7 @@ const ClassroomParamStep3 = () => {
   const textDefaultValue = `\nBonjour,\n\nNotre classe participe au projet 1Village, de l’association Par Le Monde, agréée par le ministère de l’éducation nationale français. 1Village est un projet de correspondances avec d’autres classes du monde, accessible de façon sécurisée sur un site internet.\n\nSi vous souhaitez accéder à ce site et observer les échanges en famille, il vous faut suivre cette démarche :\n\n\t1. Créer un compte sur https://1v.parlemonde.org/inscription, en renseignant une adresse email et un mot de passe.\n\t2. Confirmez votre adresse mail en cliquant sur le lien envoyé.\n\t3. Connectez-vous sur https://1v.parlemonde.org/famille et rattachez votre compte à l’identifiant unique <strong>%identifiant</strong>\n\nJusqu’à 5 personnes de votre famille peuvent créer un compte et le rattacher à l’identifiant unique de votre enfant.\n\nBonne journée\n\n`;
 
   useEffect(() => {
-    const keywordRegex = new RegExp(/%identifiant/gm);
+    const keywordRegex = /(^|\s|<[^>]*>)%identifiant(\s|$|<[^>]*>)/gm;
     if (textValue.match(keywordRegex)) {
       setKeywordPresence(true);
     } else {

--- a/types/featureFlag.constant.ts
+++ b/types/featureFlag.constant.ts
@@ -1,3 +1,3 @@
-export const FEATURE_FLAGS_NAMES = ['id-family' as const, 'toto' as const];
+export const FEATURE_FLAGS_NAMES = ['id-family' as const];
 
 export type FeatureFlagsNames = typeof FEATURE_FLAGS_NAMES[number];


### PR DESCRIPTION
### Motivation

"Petit bug repéré lors de la démo, le mot %identifiant ne peut pas être modifié si on supprime un caractère mais on peut en ajouter. Est-ce que vous pourriez bloquer la modification dans les deux sens ?"

### Changes

Changed regex in page 3 of familles/3

### Test

try adding anything after the %identifiant.
