### PR TITLE
Vil 586

### DIFF
--- a/server/controllers/statistics.ts
+++ b/server/controllers/statistics.ts
@@ -16,7 +16,13 @@ import {
   getMinConnections,
   getMinDuration,
 } from '../stats/sessionStats';
-import { getChildrenCodesCount, getFamilyAccountsCount, getConnectedFamiliesCount, getFamiliesWithoutAccount } from '../stats/villageStats';
+import {
+  getChildrenCodesCount,
+  getFamilyAccountsCount,
+  getConnectedFamiliesCount,
+  getFamiliesWithoutAccount,
+  getFloatingAccounts,
+} from '../stats/villageStats';
 import { Controller } from './controller';
 
 export const statisticsController = new Controller('/statistics');
@@ -52,5 +58,6 @@ statisticsController.get({ path: '/villages/:villageId' }, async (_req, res) => 
     childrenCodesCount: await getChildrenCodesCount(villageId),
     connectedFamiliesCount: await getConnectedFamiliesCount(villageId),
     familiesWithoutAccount: await getFamiliesWithoutAccount(villageId),
+    floatingAccounts: await getFloatingAccounts(villageId),
   });
 });

--- a/server/entities/student.ts
+++ b/server/entities/student.ts
@@ -1,4 +1,4 @@
-import { Entity, Column, ManyToOne, OneToMany, PrimaryGeneratedColumn, JoinColumn } from 'typeorm';
+import { Entity, Column, ManyToOne, OneToMany, PrimaryGeneratedColumn, JoinColumn, CreateDateColumn } from 'typeorm';
 
 import { Classroom } from './classroom';
 import { UserToStudent } from './userToStudent';
@@ -7,6 +7,9 @@ import { UserToStudent } from './userToStudent';
 export class Student {
   @PrimaryGeneratedColumn()
   public id: number;
+
+  @CreateDateColumn()
+  createdAt: Date;
 
   @Column({ type: 'varchar', length: 100, nullable: true })
   public firstname: string;

--- a/server/entities/user.ts
+++ b/server/entities/user.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, PrimaryGeneratedColumn, ManyToOne, JoinColumn, OneToMany, ManyToMany, JoinTable } from 'typeorm';
+import { Column, Entity, PrimaryGeneratedColumn, ManyToOne, JoinColumn, OneToMany, ManyToMany, JoinTable, CreateDateColumn } from 'typeorm';
 
 import type { Country } from '../../types/country.type';
 import { UserType } from '../../types/user.type';
@@ -18,6 +18,9 @@ export { UserType };
 export class User implements UserInterface {
   @PrimaryGeneratedColumn()
   public id: number;
+
+  @CreateDateColumn()
+  createdAt: Date;
 
   @Column({ type: 'varchar', length: 255, unique: true })
   public email: string;

--- a/server/migrations/1729060730152-AddCreatedAtColumnToStudentAndUserEntities.ts
+++ b/server/migrations/1729060730152-AddCreatedAtColumnToStudentAndUserEntities.ts
@@ -1,7 +1,7 @@
 import { TableColumn } from 'typeorm';
 import type { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class AddCreatedAtColumnToStudentAndUserEntities implements MigrationInterface {
+export class AddCreatedAtColumnToStudentAndUserEntities1729060730152 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.addColumn(
       'student',

--- a/server/migrations/1729060730152-AddCreatedAtColumnToStudentAndUserEntities.ts
+++ b/server/migrations/1729060730152-AddCreatedAtColumnToStudentAndUserEntities.ts
@@ -1,0 +1,50 @@
+import { TableColumn } from 'typeorm';
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddCreatedAtColumnToStudentAndUserEntities implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumn(
+      'student',
+      new TableColumn({
+        name: 'createdAt',
+        type: 'timestamp',
+        isNullable: true,
+      }),
+    );
+    await queryRunner.query(`UPDATE "student" SET "createdAt" = NULL WHERE "createdAt" IS NOT NULL`);
+    await queryRunner.changeColumn(
+      'student',
+      'createdAt',
+      new TableColumn({
+        name: 'createdAt',
+        type: 'timestamp',
+        isNullable: false,
+        default: 'CURRENT_TIMESTAMP',
+      }),
+    );
+    await queryRunner.addColumn(
+      'user',
+      new TableColumn({
+        name: 'createdAt',
+        type: 'timestamp',
+        isNullable: true,
+      }),
+    );
+    await queryRunner.query(`UPDATE "user" SET "createdAt" = NULL WHERE "createdAt" IS NOT NULL`);
+    await queryRunner.changeColumn(
+      'user',
+      'createdAt',
+      new TableColumn({
+        name: 'createdAt',
+        type: 'timestamp',
+        isNullable: false,
+        default: 'CURRENT_TIMESTAMP',
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropColumn('student', 'createdAt');
+    await queryRunner.dropColumn('user', 'createdAt');
+  }
+}

--- a/server/migrations/1729236109909-AddCreatedAtColumnToStudentAndUserEntities.ts
+++ b/server/migrations/1729236109909-AddCreatedAtColumnToStudentAndUserEntities.ts
@@ -11,7 +11,7 @@ export class AddCreatedAtColumnToStudentAndUserEntities1729236109909 implements 
         isNullable: true,
       }),
     );
-    await queryRunner.query(`UPDATE "student" SET "createdAt" = NULL WHERE "createdAt" IS NOT NULL`);
+    await queryRunner.query('UPDATE `student` SET `createdAt` = NULL WHERE `createdAt` IS NOT NULL');
     await queryRunner.changeColumn(
       'student',
       'createdAt',
@@ -30,7 +30,7 @@ export class AddCreatedAtColumnToStudentAndUserEntities1729236109909 implements 
         isNullable: true,
       }),
     );
-    await queryRunner.query(`UPDATE "user" SET "createdAt" = NULL WHERE "createdAt" IS NOT NULL`);
+    await queryRunner.query('UPDATE `user` SET `createdAt` = NULL WHERE `createdAt` IS NOT NULL');
     await queryRunner.changeColumn(
       'user',
       'createdAt',

--- a/server/migrations/1729236109909-AddCreatedAtColumnToStudentAndUserEntities.ts
+++ b/server/migrations/1729236109909-AddCreatedAtColumnToStudentAndUserEntities.ts
@@ -1,7 +1,7 @@
 import { TableColumn } from 'typeorm';
 import type { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class AddCreatedAtColumnToStudentAndUserEntities1729060730152 implements MigrationInterface {
+export class AddCreatedAtColumnToStudentAndUserEntities1729236109909 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.addColumn(
       'student',

--- a/server/stats/villageStats.ts
+++ b/server/stats/villageStats.ts
@@ -58,3 +58,13 @@ export const getFamiliesWithoutAccount = async (villageId: number) => {
 
   return familiesWithoutAccount;
 };
+
+export const getFloatingAccounts = async (villageId: number) => {
+  const floatingAccounts = await userRepository
+    .createQueryBuilder('user')
+    .where('user.villageId = :villageId', { villageId })
+    .andWhere('user.hasStudentLinked = 0')
+    .select(['user.id', 'user.firstname', 'user.lastname', 'user.language', 'user.email'])
+    .getMany();
+  return floatingAccounts;
+};

--- a/server/stats/villageStats.ts
+++ b/server/stats/villageStats.ts
@@ -64,6 +64,7 @@ export const getFloatingAccounts = async (villageId: number) => {
     .createQueryBuilder('user')
     .where('user.villageId = :villageId', { villageId })
     .andWhere('user.hasStudentLinked = 0')
+    .andWhere('user.type = 4')
     .select(['user.id', 'user.firstname', 'user.lastname', 'user.language', 'user.email'])
     .getMany();
   return floatingAccounts;

--- a/server/stats/villageStats.ts
+++ b/server/stats/villageStats.ts
@@ -52,6 +52,7 @@ export const getFamiliesWithoutAccount = async (villageId: number) => {
       'student.firstname AS student_firstname',
       'student.lastname AS student_lastname',
       'student.id AS student_id',
+      'student.createdAt as student_creation_date',
       'village.name AS village_name',
     ])
     .getRawMany();
@@ -65,7 +66,7 @@ export const getFloatingAccounts = async (villageId: number) => {
     .where('user.villageId = :villageId', { villageId })
     .andWhere('user.hasStudentLinked = 0')
     .andWhere('user.type = 4')
-    .select(['user.id', 'user.firstname', 'user.lastname', 'user.language', 'user.email'])
+    .select(['user.id', 'user.firstname', 'user.lastname', 'user.language', 'user.email', 'user.createdAt'])
     .getMany();
   return floatingAccounts;
 };

--- a/src/components/admin/OneVillageTable.tsx
+++ b/src/components/admin/OneVillageTable.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import RemoveRedEyeIcon from '@mui/icons-material/RemoveRedEye';
-import { Paper, TableContainer } from '@mui/material';
+import { Box, Paper, TableContainer, TableSortLabel, useTheme } from '@mui/material';
 import NoSsr from '@mui/material/NoSsr';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
@@ -9,8 +9,8 @@ import TableCell from '@mui/material/TableCell';
 import TableHead from '@mui/material/TableHead';
 import TablePagination from '@mui/material/TablePagination';
 import TableRow from '@mui/material/TableRow';
-import TableSortLabel from '@mui/material/TableSortLabel';
-import { useTheme } from '@mui/material/styles';
+
+import { primaryColorLight } from 'src/styles/variables.const';
 
 function paginate<T>(array: T[], pageSize: number, pageNumber: number): T[] {
   // human-readable page numbers usually start with 1, so we reduce 1 in the first argument
@@ -37,7 +37,7 @@ interface OneVillageTableProps {
 export const OneVillageTable = ({ 'aria-label': ariaLabel, emptyPlaceholder, admin, data, columns, actions, titleContent }: OneVillageTableProps) => {
   const theme = useTheme();
   const color = admin ? 'white' : 'black';
-  const backgroundColor = admin ? theme.palette.secondary.main : 'white';
+  const backgroundColor = admin ? theme.palette.secondary.main : primaryColorLight;
   const [options, setTableOptions] = React.useState<TableOptions>({
     page: 1,
     limit: 10,
@@ -70,7 +70,12 @@ export const OneVillageTable = ({ 'aria-label': ariaLabel, emptyPlaceholder, adm
 
   return (
     <NoSsr>
-      <TableContainer component={Paper}>
+      <TableContainer component={Paper} sx={{ mb: '1rem' }}>
+        {titleContent && (
+          <Box sx={{ fontWeight: 'bold', display: 'flex', border: 'none', backgroundColor, p: '8px' }}>
+            <RemoveRedEyeIcon sx={{ mr: '6px' }} /> {titleContent}
+          </Box>
+        )}
         <Table size="medium" aria-label={ariaLabel}>
           {data.length === 0 ? (
             <TableBody>
@@ -84,15 +89,14 @@ export const OneVillageTable = ({ 'aria-label': ariaLabel, emptyPlaceholder, adm
             <>
               <TableHead
                 style={{ borderBottom: '1px solid white' }}
-                sx={{ fontWeight: 'bold', minHeight: 'unset', padding: '8px 8px 8px 16px', color, backgroundColor }}
+                sx={{
+                  fontWeight: 'bold',
+                  minHeight: 'unset',
+                  padding: '8px 8px 8px 16px',
+                  color,
+                  backgroundColor: admin ? backgroundColor : 'white',
+                }}
               >
-                {titleContent && (
-                  <TableRow>
-                    <TableCell sx={{ fontWeight: 'bold', display: 'flex', border: 'none' }}>
-                      <RemoveRedEyeIcon sx={{ mr: '6px' }} /> {titleContent}
-                    </TableCell>
-                  </TableRow>
-                )}
                 <TableRow>
                   {columns.map((c) => (
                     <TableCell key={c.key} style={{ color, fontWeight: 'bold' }}>

--- a/src/components/admin/dashboard-statistics/VillageStats.tsx
+++ b/src/components/admin/dashboard-statistics/VillageStats.tsx
@@ -14,6 +14,7 @@ import styles from './styles/charts.module.css';
 import { useGetVillagesStats } from 'src/api/statistics/statistics.get';
 import { useCountries } from 'src/services/useCountries';
 import { useVillages } from 'src/services/useVillages';
+import { formatDate } from 'src/utils';
 import type { FamiliesWithoutAccount, OneVillageTableRow } from 'types/statistics.type';
 import type { VillageFilter } from 'types/village.type';
 
@@ -96,7 +97,7 @@ const VillageStats = () => {
         vm: row.village_name,
         classroom: row.classroom_name,
         country: row.classroom_country,
-        creationDate: 'À venir',
+        creationDate: row.student_creation_date ? formatDate(row.student_creation_date) : 'Donnée non disponible',
       };
     });
   }

--- a/src/components/admin/dashboard-statistics/VillageStats.tsx
+++ b/src/components/admin/dashboard-statistics/VillageStats.tsx
@@ -23,6 +23,7 @@ const VillageStats = () => {
   const [options, setOptions] = useState<VillageFilter>({ countryIsoCode: '' });
 
   const pelicoMessage = 'Merci de sélectionner un village-monde pour analyser ses statistiques ';
+  const noDataFoundMessage = 'Pas de données pour le Village-Monde sélectionné';
 
   const { countries } = useCountries();
 
@@ -153,14 +154,14 @@ const VillageStats = () => {
           <>
             <OneVillageTable
               admin={false}
-              emptyPlaceholder={<p>{pelicoMessage}</p>}
+              emptyPlaceholder={<p>{noDataFoundMessage}</p>}
               data={familiesWithoutAccountRows}
               columns={FamiliesWithoutAccountHeaders}
               titleContent={`À surveiller : comptes non créés (${familiesWithoutAccountRows.length})`}
             />
             <OneVillageTable
               admin={false}
-              emptyPlaceholder={<p>{pelicoMessage}</p>}
+              emptyPlaceholder={<p>{noDataFoundMessage}</p>}
               data={floatingAccountsRows}
               columns={FloatingAccountsHeaders}
               titleContent={`À surveiller : comptes flottants (${floatingAccountsRows.length})`}

--- a/src/components/admin/dashboard-statistics/VillageStats.tsx
+++ b/src/components/admin/dashboard-statistics/VillageStats.tsx
@@ -14,7 +14,7 @@ import styles from './styles/charts.module.css';
 import { useGetVillagesStats } from 'src/api/statistics/statistics.get';
 import { useCountries } from 'src/services/useCountries';
 import { useVillages } from 'src/services/useVillages';
-import type { FamiliesWithoutAccount, FloatingAccount, OneVillageTableRow } from 'types/statistics.type';
+import type { FamiliesWithoutAccount, OneVillageTableRow } from 'types/statistics.type';
 import type { VillageFilter } from 'types/village.type';
 
 const VillageStats = () => {
@@ -36,13 +36,10 @@ const VillageStats = () => {
   }, [selectedCountry]);
 
   const [familiesWithoutAccountRows, setFamiliesWithoutAccountRows] = React.useState<Array<OneVillageTableRow>>([]);
-  const [floatingAccountsRows, setFloatingAccountsRows] = React.useState<Array<OneVillageTableRow>>([]);
   React.useEffect(() => {
     if (villagesStats.data?.familiesWithoutAccount) {
       setFamiliesWithoutAccountRows([]);
-      setFloatingAccountsRows([]);
       setFamiliesWithoutAccountRows(createFamiliesWithoutAccountRows(villagesStats.data?.familiesWithoutAccount));
-      setFloatingAccountsRows(createFloatingAccountsRows(villagesStats.data?.floatingAccounts));
     }
   }, [villagesStats.data?.familiesWithoutAccount, villagesStats.data?.floatingAccounts]);
 
@@ -78,12 +75,6 @@ const VillageStats = () => {
     { key: 'country', label: 'Pays', sortable: true },
     { key: 'creationDate', label: 'Date de création identifiant', sortable: true },
   ];
-  const FloatingAccountsHeaders = [
-    { key: 'family', label: 'Nom Prénom Famille', sortable: true },
-    { key: 'language', label: 'Langue', sortable: true },
-    { key: 'email', label: 'Mail', sortable: true },
-    { key: 'creationDate', label: 'Date de création compte', sortable: true },
-  ];
   function CustomTabPanel(props: TabPanelProps) {
     const { children, value, index, ...other } = props;
 
@@ -105,17 +96,6 @@ const VillageStats = () => {
         vm: row.village_name,
         classroom: row.classroom_name,
         country: row.classroom_country,
-        creationDate: 'À venir',
-      };
-    });
-  }
-  function createFloatingAccountsRows(data: Array<FloatingAccount>): Array<OneVillageTableRow> {
-    return data.map((row) => {
-      return {
-        id: row.id,
-        family: `${row.firstname} ${row.lastname}`,
-        language: row.language,
-        email: row.email,
         creationDate: 'À venir',
       };
     });
@@ -158,13 +138,6 @@ const VillageStats = () => {
               data={familiesWithoutAccountRows}
               columns={FamiliesWithoutAccountHeaders}
               titleContent={`À surveiller : comptes non créés (${familiesWithoutAccountRows.length})`}
-            />
-            <OneVillageTable
-              admin={false}
-              emptyPlaceholder={<p>{noDataFoundMessage}</p>}
-              data={floatingAccountsRows}
-              columns={FloatingAccountsHeaders}
-              titleContent={`À surveiller : comptes flottants (${floatingAccountsRows.length})`}
             />
             <Box
               className={styles.classroomStats}

--- a/src/components/admin/dashboard-statistics/VillageStats.tsx
+++ b/src/components/admin/dashboard-statistics/VillageStats.tsx
@@ -14,6 +14,7 @@ import styles from './styles/charts.module.css';
 import { useGetVillagesStats } from 'src/api/statistics/statistics.get';
 import { useCountries } from 'src/services/useCountries';
 import { useVillages } from 'src/services/useVillages';
+import type { FamiliesWithoutAccount, FloatingAccount, OneVillageTableRow } from 'types/statistics.type';
 import type { VillageFilter } from 'types/village.type';
 
 const VillageStats = () => {
@@ -33,13 +34,16 @@ const VillageStats = () => {
     });
   }, [selectedCountry]);
 
-  const [rows, setRows] = React.useState<Array<{ id: string | number; [key: string]: string | boolean | number | React.ReactNode }>>([]);
+  const [familiesWithoutAccountRows, setFamiliesWithoutAccountRows] = React.useState<Array<OneVillageTableRow>>([]);
+  const [floatingAccountsRows, setFloatingAccountsRows] = React.useState<Array<OneVillageTableRow>>([]);
   React.useEffect(() => {
     if (villagesStats.data?.familiesWithoutAccount) {
-      setRows([]);
-      setRows(createRows(villagesStats.data?.familiesWithoutAccount));
+      setFamiliesWithoutAccountRows([]);
+      setFloatingAccountsRows([]);
+      setFamiliesWithoutAccountRows(createFamiliesWithoutAccountRows(villagesStats.data?.familiesWithoutAccount));
+      setFloatingAccountsRows(createFloatingAccountsRows(villagesStats.data?.floatingAccounts));
     }
-  }, [villagesStats.data?.familiesWithoutAccount]);
+  }, [villagesStats.data?.familiesWithoutAccount, villagesStats.data?.floatingAccounts]);
 
   const handleCountryChange = (country: string) => {
     setSelectedCountry(country);
@@ -73,6 +77,12 @@ const VillageStats = () => {
     { key: 'country', label: 'Pays', sortable: true },
     { key: 'creationDate', label: 'Date de création identifiant', sortable: true },
   ];
+  const FloatingAccountsHeaders = [
+    { key: 'family', label: 'Nom Prénom Famille', sortable: true },
+    { key: 'language', label: 'Langue', sortable: true },
+    { key: 'email', label: 'Mail', sortable: true },
+    { key: 'creationDate', label: 'Date de création compte', sortable: true },
+  ];
   function CustomTabPanel(props: TabPanelProps) {
     const { children, value, index, ...other } = props;
 
@@ -86,24 +96,26 @@ const VillageStats = () => {
       </div>
     );
   }
-  function createRows(
-    data: Array<{
-      student_id: string | number;
-      student_firstname: string;
-      student_lastname: string;
-      village_name: string;
-      classroom_name: string;
-      classroom_country: string;
-    }>,
-  ): Array<{ id: string | number; [key: string]: string | boolean | number | React.ReactNode }> {
+  function createFamiliesWithoutAccountRows(data: Array<FamiliesWithoutAccount>): Array<OneVillageTableRow> {
     return data.map((row) => {
       return {
-        id: row.student_id, // id is string | number
-        student: `${row.student_firstname} ${row.student_lastname}`, // string
-        vm: row.village_name, // string
-        classroom: row.classroom_name, // string
-        country: row.classroom_country, // string
-        creationDate: 'À venir', // string
+        id: row.student_id,
+        student: `${row.student_firstname} ${row.student_lastname}`,
+        vm: row.village_name,
+        classroom: row.classroom_name,
+        country: row.classroom_country,
+        creationDate: 'À venir',
+      };
+    });
+  }
+  function createFloatingAccountsRows(data: Array<FloatingAccount>): Array<OneVillageTableRow> {
+    return data.map((row) => {
+      return {
+        id: row.id,
+        family: `${row.firstname} ${row.lastname}`,
+        language: row.language,
+        email: row.email,
+        creationDate: 'À venir',
       };
     });
   }
@@ -142,9 +154,16 @@ const VillageStats = () => {
             <OneVillageTable
               admin={false}
               emptyPlaceholder={<p>{pelicoMessage}</p>}
-              data={rows}
+              data={familiesWithoutAccountRows}
               columns={FamiliesWithoutAccountHeaders}
-              titleContent={`À surveiller : comptes non créés (${rows.length})`}
+              titleContent={`À surveiller : comptes non créés (${familiesWithoutAccountRows.length})`}
+            />
+            <OneVillageTable
+              admin={false}
+              emptyPlaceholder={<p>{pelicoMessage}</p>}
+              data={floatingAccountsRows}
+              columns={FloatingAccountsHeaders}
+              titleContent={`À surveiller : comptes flottants (${floatingAccountsRows.length})`}
             />
             <Box
               className={styles.classroomStats}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -106,6 +106,15 @@ export function countryToFlag(isoCode: string): string {
     : isoCode;
 }
 
+export function formatDate(isoString: string): string {
+  const date = new Date(isoString);
+  const day = date.getUTCDate().toString().padStart(2, '0');
+  const month = (date.getUTCMonth() + 1).toString().padStart(2, '0');
+  const year = date.getUTCFullYear();
+  const formattedDate = `${day}/${month}/${year}`;
+  return formattedDate;
+}
+
 /**
  * Returns a random token. Browser only!
  * @param length length of the returned token.

--- a/types/statistics.type.ts
+++ b/types/statistics.type.ts
@@ -31,6 +31,7 @@ export interface VillageStats {
   familyAccountsCount: number;
   connectedFamiliesCount: number;
   familiesWithoutAccount: FamiliesWithoutAccount[];
+  floatingAccounts: FloatingAccount[];
 }
 
 export interface FamiliesWithoutAccount {
@@ -40,4 +41,17 @@ export interface FamiliesWithoutAccount {
   village_name: string;
   classroom_name: string;
   classroom_country: string;
+}
+
+export interface FloatingAccount {
+  id: number;
+  email: string;
+  firstname: string;
+  lastname: string;
+  language: string;
+}
+
+export interface OneVillageTableRow {
+  id: string | number;
+  [key: string]: string | boolean | number | React.ReactNode;
 }

--- a/types/statistics.type.ts
+++ b/types/statistics.type.ts
@@ -38,6 +38,7 @@ export interface FamiliesWithoutAccount {
   student_id: number;
   student_firstname: string;
   student_lastname: string;
+  student_creation_date: string | null;
   village_name: string;
   classroom_name: string;
   classroom_country: string;
@@ -49,6 +50,7 @@ export interface FloatingAccount {
   firstname: string;
   lastname: string;
   language: string;
+  createdAt: string | null;
 }
 
 export interface OneVillageTableRow {


### PR DESCRIPTION
### Motivation

In the analytics tab of a given village, the user should be able to see the families without account in the table, along with the date of their student id's creation

### Changes

- Added requests to get floating account data
- Added `createdAt` column to *User* and *Student* tables
- Updated some styles to get better looking tables in the analytics part

### Test

As an administrator, visit the analytics part of the application. Select the *Village* tab and select a specific village. A table displaying the families that were registered but did not create an account should appear. 
