### PR TITLE
feat/VIL-616 (phase history and filter by phase)

### DIFF
--- a/server/controllers/phaseHistory.ts
+++ b/server/controllers/phaseHistory.ts
@@ -1,0 +1,67 @@
+import { PhaseHistory } from '../entities/phaseHistory';
+import { Village, VillagePhase } from '../entities/village';
+import { AppDataSource } from '../utils/data-source';
+import { Controller } from './controller';
+
+const handlePhase1toPhase3Case = async (village: Village, phase: number) => {
+  if (village.activePhase === VillagePhase.DISCOVER && phase === VillagePhase.IMAGINE) {
+    const phaseHistory = new PhaseHistory();
+    phaseHistory.village = village;
+    phaseHistory.phase = VillagePhase.EXCHANGE;
+    phaseHistory.endingOn = new Date();
+
+    const phaseHistoryRepository = AppDataSource.getRepository(PhaseHistory);
+
+    await phaseHistoryRepository.save(phaseHistory);
+
+    const endPhase1Query = phaseHistoryRepository
+      .createQueryBuilder()
+      .softDelete()
+      .where('villageId = :villageId', { villageId: village.id })
+      .andWhere('phase = :phase', { phase: VillagePhase.DISCOVER });
+    await endPhase1Query.execute();
+  }
+};
+export const phaseHistoryController = new Controller('/phase-history');
+
+phaseHistoryController.post({ path: '/' }, async (_req, res) => {
+  const data = _req.body;
+  try {
+    //Find village wit a given id
+    const villageRepository = AppDataSource.getRepository(Village);
+    const village = await villageRepository.findOne({ where: { id: data.villageId } });
+    if (!village) throw new Error('Village Not found');
+
+    await handlePhase1toPhase3Case(village, data.phase);
+
+    // Create a PhaseHistory instance and fill it with data
+    const phaseHistory = new PhaseHistory();
+    phaseHistory.village = village;
+    phaseHistory.phase = data.phase;
+    phaseHistory.startingOn = new Date();
+
+    // Save phase history in db
+    const phaseHistoryRepository = AppDataSource.getRepository(PhaseHistory);
+    await phaseHistoryRepository.save(phaseHistory);
+    res.sendStatus(200);
+  } catch (e) {
+    console.error(e);
+  }
+});
+
+phaseHistoryController.delete({ path: '/soft-delete/:villageId/:phase' }, async (_req, res) => {
+  const { villageId, phase } = _req.params;
+  const phaseHistoryRepository = AppDataSource.getRepository(PhaseHistory);
+  const query = phaseHistoryRepository
+    .createQueryBuilder()
+    .softDelete()
+    .where('villageId = :villageId', { villageId })
+    .andWhere('phase = :phase', { phase });
+
+  try {
+    await query.execute();
+    res.sendStatus(202);
+  } catch (e) {
+    console.error(e);
+  }
+});

--- a/server/controllers/statistics.ts
+++ b/server/controllers/statistics.ts
@@ -63,10 +63,11 @@ statisticsController.get({ path: '/onevillage' }, async (_req, res) => {
 
 statisticsController.get({ path: '/villages/:villageId' }, async (_req, res) => {
   const villageId = parseInt(_req.params.villageId);
+  const phase = _req.query.phase as unknown as number;
   res.sendJSON({
-    familyAccountsCount: await getFamilyAccountsCount(villageId),
-    childrenCodesCount: await getChildrenCodesCount(villageId),
-    connectedFamiliesCount: await getConnectedFamiliesCount(villageId),
+    familyAccountsCount: await getFamilyAccountsCount(villageId, phase),
+    childrenCodesCount: await getChildrenCodesCount(villageId, phase),
+    connectedFamiliesCount: await getConnectedFamiliesCount(villageId, phase),
     familiesWithoutAccount: await getFamiliesWithoutAccount(villageId),
     floatingAccounts: await getFloatingAccounts(villageId),
   });

--- a/server/entities/phaseHistory.ts
+++ b/server/entities/phaseHistory.ts
@@ -1,0 +1,25 @@
+import { Column, CreateDateColumn, DeleteDateColumn, Entity, Index, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+
+import type { VillagePhase } from './village';
+import { Village } from './village';
+
+@Entity()
+@Index('IDX_PHASE_HISTORY', ['village', 'phase'], { unique: true })
+export class PhaseHistory {
+  @PrimaryGeneratedColumn()
+  public id: number;
+
+  @ManyToOne(() => Village, (village) => village.phaseHistories, { onDelete: 'CASCADE' })
+  village: Village;
+
+  @Column({
+    type: 'tinyint',
+  })
+  phase: VillagePhase;
+
+  @CreateDateColumn({ type: 'datetime' })
+  public startingOn: Date;
+
+  @DeleteDateColumn({ type: 'datetime' })
+  public endingOn: Date;
+}

--- a/server/entities/village.ts
+++ b/server/entities/village.ts
@@ -9,6 +9,7 @@ import { Classroom } from './classroom';
 import { Game } from './game';
 import { GameResponse } from './gameResponse';
 import { Image } from './image';
+import { PhaseHistory } from './phaseHistory';
 import { User } from './user';
 
 export { VillagePhase };
@@ -38,6 +39,9 @@ export class Village implements VillageInterface {
     default: VillagePhase.DISCOVER,
   })
   public activePhase: number;
+
+  @OneToMany(() => PhaseHistory, (phaseHistory) => phaseHistory.village, { eager: true })
+  public phaseHistories: PhaseHistory[];
 
   @OneToOne(() => Activity, { onDelete: 'SET NULL' })
   @JoinColumn({ name: 'anthemId' })

--- a/server/migrations/1731486908522-AddPhaseHistory.ts
+++ b/server/migrations/1731486908522-AddPhaseHistory.ts
@@ -1,0 +1,82 @@
+import { Table, TableForeignKey, TableIndex } from 'typeorm';
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddPhaseHistory1731486908522 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'phase_history',
+        columns: [
+          {
+            name: 'id',
+            type: 'int',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          {
+            name: 'villageId',
+            type: 'int',
+            isNullable: false,
+          },
+          {
+            name: 'phase',
+            type: 'tinyint',
+          },
+          {
+            name: 'startingOn',
+            type: 'datetime',
+          },
+          {
+            name: 'endingOn',
+            type: 'datetime',
+            isNullable: true,
+          },
+        ],
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'phase_history',
+      new TableIndex({
+        name: 'IDX_PHASE_HISTORY',
+        columnNames: ['villageId', 'phase'],
+        isUnique: true,
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      'phase_history',
+      new TableForeignKey({
+        columnNames: ['villageId'],
+        referencedColumnNames: ['id'],
+        referencedTableName: 'village',
+        onDelete: 'CASCADE',
+      }),
+    );
+
+    const villages = await queryRunner.query(`SELECT id FROM village`);
+    const startingOn2024Phase1Date = '2024-09-30 00:00:00.000000';
+
+    for (const village of villages) {
+      await queryRunner.query(`INSERT INTO phase_history (villageId, phase, startingOn, endingOn) VALUES (?, ?, ?, ?)`, [
+        village.id,
+        1,
+        startingOn2024Phase1Date,
+        null,
+      ]);
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    const table = await queryRunner.getTable('phase_history');
+    if (table) {
+      const foreignKey = table.foreignKeys.find((fk) => fk.columnNames.indexOf('villageId') !== -1);
+      if (foreignKey) {
+        await queryRunner.dropForeignKey('phase_history', foreignKey);
+        await queryRunner.dropIndex('phase_history', 'IDX_PHASE_HISTORY');
+        await queryRunner.dropTable('phase_history');
+      }
+    }
+  }
+}

--- a/src/api/phaseHistory/phaseHistory.delete.ts
+++ b/src/api/phaseHistory/phaseHistory.delete.ts
@@ -1,0 +1,15 @@
+import type { PhaseHistory } from 'server/entities/phaseHistory';
+
+import { axiosRequest } from 'src/utils/axiosRequest';
+
+export async function softDeletePhaseHistory(villageId: number, phase: number): Promise<PhaseHistory> {
+  const response = await axiosRequest<PhaseHistory>({
+    method: 'DELETE',
+    url: `/phase-history/soft-delete/${villageId}/${phase}`,
+  });
+  if (response.error) {
+    throw new Error("Erreur lors de la suppresion de l'historique des phases. Veuillez réessayer.");
+  }
+
+  return response.data;
+}

--- a/src/api/phaseHistory/phaseHistory.post.ts
+++ b/src/api/phaseHistory/phaseHistory.post.ts
@@ -1,0 +1,16 @@
+import type { PhaseHistory } from 'server/entities/phaseHistory';
+
+import { axiosRequest } from 'src/utils/axiosRequest';
+
+export async function postPhaseHistory(data: Partial<PhaseHistory> & { villageId: number }): Promise<PhaseHistory> {
+  const response = await axiosRequest<PhaseHistory>({
+    method: 'POST',
+    url: '/phase-history',
+    data,
+  });
+  if (response.error) {
+    throw new Error("Erreur lors de la création de l'historique des phases. Veuillez réessayer.");
+  }
+
+  return response.data;
+}

--- a/src/api/statistics/statistics.get.ts
+++ b/src/api/statistics/statistics.get.ts
@@ -23,12 +23,12 @@ async function getOneVillageStats(): Promise<VillageStats> {
   ).data;
 }
 
-async function getVillagesStats(villageId: number | null): Promise<VillageStats> {
+async function getVillagesStats(villageId: number | null, phase: number): Promise<VillageStats> {
   return (
     await axiosRequest({
       method: 'GET',
       baseURL: '/api',
-      url: `/statistics/villages/${villageId}`,
+      url: phase ? `/statistics/villages/${villageId}?phase=${phase}` : `/statistics/villages/${villageId}`,
     })
   ).data;
 }
@@ -40,8 +40,8 @@ export const useGetOneVillageStats = () => {
   return useQuery(['1v-stats'], () => getOneVillageStats());
 };
 
-export const useGetVillagesStats = (villageId: number | null) => {
-  return useQuery(['villages-stats', villageId], () => getVillagesStats(villageId), {
+export const useGetVillagesStats = (villageId: number | null, phase: number) => {
+  return useQuery(['villages-stats', villageId, phase], () => getVillagesStats(villageId, phase), {
     enabled: villageId !== null,
   });
 };

--- a/src/components/admin/dashboard-statistics/VillageStats.tsx
+++ b/src/components/admin/dashboard-statistics/VillageStats.tsx
@@ -8,6 +8,7 @@ import { OneVillageTable } from '../OneVillageTable';
 import TabPanel from './TabPanel';
 import StatsCard from './cards/StatsCard/StatsCard';
 import CountriesDropdown from './filters/CountriesDropdown';
+import PhaseDropdown from './filters/PhaseDropdown';
 import VillageDropdown from './filters/VillageDropdown';
 import { PelicoCard } from './pelico-card';
 import styles from './styles/charts.module.css';
@@ -24,11 +25,12 @@ const VillageStats = () => {
   const [selectedVillage, setSelectedVillage] = useState<string>('');
   const [options, setOptions] = useState<VillageFilter>({ countryIsoCode: '' });
   const [value, setValue] = React.useState(0);
+  const [selectedPhase, setSelectedPhase] = React.useState<number>(0);
 
   const { countries } = useCountries();
 
   const { villages } = useVillages(options);
-  const villagesStats = useGetVillagesStats(+selectedVillage);
+  const villagesStats = useGetVillagesStats(+selectedVillage, selectedPhase);
   React.useEffect(() => {
     setOptions({
       countryIsoCode: selectedCountry,
@@ -51,6 +53,10 @@ const VillageStats = () => {
     setSelectedVillage(village);
   };
 
+  const handlePhaseChange = (phase: string) => {
+    setSelectedPhase(+phase);
+  };
+
   const handleTabChange = (_event: React.SyntheticEvent, newValue: number) => {
     setValue(newValue);
   };
@@ -70,6 +76,9 @@ const VillageStats = () => {
           gap: 2,
         }}
       >
+        <div className={styles.countryFilter}>
+          <PhaseDropdown onPhaseChange={handlePhaseChange} />
+        </div>
         <div className={styles.countryFilter}>
           <CountriesDropdown countries={countries} onCountryChange={handleCountryChange} />
         </div>

--- a/src/components/admin/dashboard-statistics/filters/PhaseDropdown.tsx
+++ b/src/components/admin/dashboard-statistics/filters/PhaseDropdown.tsx
@@ -12,7 +12,7 @@ interface PhaseDropdownProps {
 }
 
 export default function PhaseDropdown({ onPhaseChange }: PhaseDropdownProps) {
-  const [phase, setPhase] = React.useState('4');
+  const [phase, setPhase] = React.useState('0');
 
   const handleChange = (event: SelectChangeEvent) => {
     const selectedPhase = event.target.value as string;
@@ -25,7 +25,7 @@ export default function PhaseDropdown({ onPhaseChange }: PhaseDropdownProps) {
       <FormControl fullWidth size="small">
         <InputLabel id="phase-menu-select">Phase</InputLabel>
         <Select labelId="phase-menu-select" id="phase-menu" value={phase} label="Phase" onChange={handleChange}>
-          <MenuItem value={4} selected>
+          <MenuItem value={0} selected>
             Toutes les phases
           </MenuItem>
           <MenuItem value={1}>Phase 1</MenuItem>

--- a/src/services/useVillages.ts
+++ b/src/services/useVillages.ts
@@ -3,8 +3,10 @@ import React from 'react';
 import type { QueryFunction } from 'react-query';
 import { useQueryClient, useQuery } from 'react-query';
 
+import { postPhaseHistory } from 'src/api/phaseHistory/phaseHistory.post';
 import { axiosRequest } from 'src/utils/axiosRequest';
 import type { Village, VillageFilter } from 'types/village.type';
+import { VillagePhase } from 'types/village.type';
 
 export const useVillages = (options?: VillageFilter): { villages: Village[]; setVillages(newVillages: Village[]): void } => {
   const queryClient = useQueryClient();
@@ -64,6 +66,10 @@ export const useVillageRequests = () => {
           name: newVillage.name,
           countries: newVillage.countries.map((c) => c.isoCode),
         },
+      });
+      await postPhaseHistory({
+        villageId: response.data.id,
+        phase: VillagePhase.DISCOVER,
       });
       if (response.error) {
         enqueueSnackbar('Une erreur est survenue...', {


### PR DESCRIPTION
### Motivation

Enable filtering on a given phase for a given village.

### Changes

Created a `phaseHistory` entity to track the starting and ending dates of phases for all villages.
Created a phase filter on the statistics dashboard.
Made sure that teachers cannot rollback on a past phase.

### Test

When you're logged in as a teacher, create a new *student* and note what is the active phase.
Using the phase filter, you should see the newly created *student* on the statistics dashboard when you're logged in as an administrator. Note that the table is displaying all data, whereas the purple cards display data by phases.

