### PR TITLE
VIL-788: fix error 500 on staging and prod

### DIFF
--- a/server/controllers/statistics/statistics.repository.ts
+++ b/server/controllers/statistics/statistics.repository.ts
@@ -61,7 +61,10 @@ export const getActivityTypeCountByVillages = async (params?: GetActivityTypeCou
 
 const getActivityCounts = async (activities: Activity[], phaseId: number) => {
   const draftCount = activities.filter((activity: Activity) => activity.status === ActivityStatus.DRAFT).length;
-  const videoCount = activities.reduce((count, activity) => count + activity.content.filter((content) => content.type === 'video').length, 0);
+  const videoCount = activities.reduce(
+    (count, activity) => count + (Array.isArray(activity.content) ? activity.content.filter((content) => content.type === 'video').length : 0),
+    0,
+  );
   const commentCount = await getCommentCountForActivities(activities.map((activity) => activity.id));
 
   const baseActivityCount = { phaseId, draftCount, videoCount, commentCount };

--- a/src/components/admin/dashboard-statistics/ClassroomStats.tsx
+++ b/src/components/admin/dashboard-statistics/ClassroomStats.tsx
@@ -69,10 +69,10 @@ const ClassroomStats = () => {
   const [familiesWithoutAccountRows, setFamiliesWithoutAccountRows] = React.useState<Array<OneVillageTableRow>>([]);
 
   useEffect(() => {
-    if (classroomsStats.data?.family.familiesWithoutAccount) {
-      setFamiliesWithoutAccountRows(createFamiliesWithoutAccountRows(classroomsStats.data?.family.familiesWithoutAccount));
+    if (classroomsStats.data?.family?.familiesWithoutAccount) {
+      setFamiliesWithoutAccountRows(createFamiliesWithoutAccountRows(classroomsStats.data.family.familiesWithoutAccount));
     }
-  }, [classroomsStats.data?.family.familiesWithoutAccount]);
+  }, [classroomsStats.data?.family?.familiesWithoutAccount]);
 
   const handleVillageChange = (village: string) => {
     setSelectedVillage(village);
@@ -184,8 +184,8 @@ const ClassroomStats = () => {
                 gap: 2,
               }}
             >
-              <StatsCard data={classroomsStats.data?.family.childrenCodesCount}>Nombre de codes enfant créés</StatsCard>
-              <StatsCard data={classroomsStats.data?.family.connectedFamiliesCount}>Nombre de familles connectées</StatsCard>
+              <StatsCard data={classroomsStats.data?.family?.childrenCodesCount}>Nombre de codes enfant créés</StatsCard>
+              <StatsCard data={classroomsStats.data?.family?.connectedFamiliesCount}>Nombre de familles connectées</StatsCard>
             </Box>
           </>
         )}

--- a/src/components/admin/dashboard-statistics/VillageStats.tsx
+++ b/src/components/admin/dashboard-statistics/VillageStats.tsx
@@ -55,10 +55,10 @@ const VillageStats = () => {
   const [familiesWithoutAccountRows, setFamiliesWithoutAccountRows] = React.useState<Array<OneVillageTableRow>>([]);
 
   useEffect(() => {
-    if (villagesStats.data?.family.familiesWithoutAccount) {
-      setFamiliesWithoutAccountRows(createFamiliesWithoutAccountRows(villagesStats.data?.family.familiesWithoutAccount));
+    if (villagesStats.data?.family?.familiesWithoutAccount) {
+      setFamiliesWithoutAccountRows(createFamiliesWithoutAccountRows(villagesStats.data.family.familiesWithoutAccount));
     }
-  }, [villagesStats.data?.family.familiesWithoutAccount]);
+  }, [villagesStats.data?.family?.familiesWithoutAccount]);
 
   const handleCountryChange = (country: string) => {
     setSelectedCountry(country);
@@ -134,7 +134,7 @@ const VillageStats = () => {
           <StatsCard data={statisticsSessions.connectedClassroomsCount ? statisticsSessions.connectedClassroomsCount : 0}>
             Nombre de classes connectées
           </StatsCard>
-          <StatsCard data={statisticsSessions.contribuedClassroomsCount ? statisticsSessions.contribuedClassroomsCount : 0}>
+          <StatsCard data={statisticsSessions.contributedClassroomsCount ? statisticsSessions.contributedClassroomsCount : 0}>
             Nombre de classes contributrices
           </StatsCard>
         </div>
@@ -208,9 +208,9 @@ const VillageStats = () => {
                 gap: 2,
               }}
             >
-              <StatsCard data={villagesStats.data?.family.familyAccountsCount}>Nombre de profs ayant créé des comptes famille</StatsCard>
-              <StatsCard data={villagesStats.data?.family.childrenCodesCount}>Nombre de codes enfant créés</StatsCard>
-              <StatsCard data={villagesStats.data?.family.connectedFamiliesCount}>Nombre de familles connectées</StatsCard>
+              <StatsCard data={villagesStats.data?.family?.familyAccountsCount}>Nombre de profs ayant créé des comptes famille</StatsCard>
+              <StatsCard data={villagesStats.data?.family?.childrenCodesCount}>Nombre de codes enfant créés</StatsCard>
+              <StatsCard data={villagesStats.data?.family?.connectedFamiliesCount}>Nombre de familles connectées</StatsCard>
             </Box>
           </>
         )}


### PR DESCRIPTION


### Motivation

Fix critical bugs causing 500 errors and user disconnections when clicking on tabs (Village-monde, Classe, Données) in staging/production environments. The issues were:

1. `TypeError: Cannot read properties of undefined (reading 'familiesWithoutAccount')` - Frontend accessing undefined `family` object
2. `"activity.content.filter is not a function"` - Backend trying to call `.filter()` on undefined/non-array `activity.content`
3. Typo in property name causing additional type errors

These errors were causing users to be logged out unexpectedly when navigating between statistics tabs.

### Changes

**Frontend fixes:**
- `src/components/admin/dashboard-statistics/ClassroomStats.tsx`: Added proper null checks with `?.family?.` instead of `?.family.` before accessing `familiesWithoutAccount`, `childrenCodesCount`, and `connectedFamiliesCount`
- `src/components/admin/dashboard-statistics/VillageStats.tsx`: Fixed typo `contribuedClassroomsCount` → `contributedClassroomsCount`

**Backend fixes:**
- `server/controllers/statistics/statistics.repository.ts`: Added `Array.isArray(activity.content)` check before calling `.filter()` to prevent "filter is not a function" errors when `activity.content` is undefined or not an array

### Test

1. **Staging/Production test:**
   - Navigate to admin dashboard statistics page
   - Click on each tab: "Village-monde", "Classe", "Données" 
   - Verify no 500 errors occur in network tab
   - Verify user stays logged in and doesn't get redirected to login page
   - Verify statistics display correctly without JavaScript errors in console

