### PR TITLE
feat(VIL-77): add dashbord statistics details for onglet PAYS - Front…

### DIFF
--- a/src/components/admin/OneVillageTable.tsx
+++ b/src/components/admin/OneVillageTable.tsx
@@ -38,6 +38,7 @@ interface OneVillageTableProps {
   usePagination?: boolean;
   minTableHeightInPx?: number;
   rowStyle?: (row: any) => React.CSSProperties;
+  tableLayout?: 'auto' | 'fixed';
 }
 
 export const OneVillageTable = ({
@@ -52,6 +53,7 @@ export const OneVillageTable = ({
   usePagination: usePaginationProp,
   minTableHeightInPx = 240,
   rowStyle,
+  tableLayout = 'fixed',
 }: OneVillageTableProps) => {
   const theme = useTheme();
   const backgroundColor = admin ? theme.palette.secondary.main : primaryColorLight;
@@ -139,7 +141,7 @@ export const OneVillageTable = ({
               <RemoveRedEyeIcon sx={{ mr: '6px' }} /> {titleContent}
             </Box>
           )}
-          <Table size="small" aria-label={ariaLabel} sx={{ tableLayout: 'fixed' }}>
+          <Table size="small" aria-label={ariaLabel} sx={{ tableLayout }}>
             {data.length === 0 ? (
               <TableBody>
                 <TableRow sx={{ height: '242px' }}>

--- a/src/components/admin/OneVillageTable.tsx
+++ b/src/components/admin/OneVillageTable.tsx
@@ -37,6 +37,7 @@ interface OneVillageTableProps {
   footerElementsLabel?: string;
   usePagination?: boolean;
   minTableHeightInPx?: number;
+  rowStyle?: (row: any) => React.CSSProperties;
 }
 
 export const OneVillageTable = ({
@@ -50,6 +51,7 @@ export const OneVillageTable = ({
   footerElementsLabel = 'élément',
   usePagination: usePaginationProp,
   minTableHeightInPx = 240,
+  rowStyle,
 }: OneVillageTableProps) => {
   const theme = useTheme();
   const backgroundColor = admin ? theme.palette.secondary.main : primaryColorLight;
@@ -130,7 +132,7 @@ export const OneVillageTable = ({
 
   return (
     <NoSsr>
-      <Paper sx={{ width: '100%', overflow: 'hidden', border: '1px solid blue', borderRadius: '24px', boxShadow: 'none' }}>
+      <Paper sx={{ width: '100%', overflow: 'hidden' }}>
         <TableContainer sx={{ minHeight: `${minTableHeightInPx + 2}px` }}>
           {titleContent && (
             <Box sx={{ fontWeight: 'bold', display: 'flex', border: 'none', backgroundColor, p: '8px' }}>
@@ -214,10 +216,16 @@ export const OneVillageTable = ({
                   }}
                 >
                   {displayedData.map((d, index) => (
-                    <TableRow key={d.id}>
+                    <TableRow key={d.id} style={rowStyle ? rowStyle(d) : {}}>
                       {columns.map((c) => {
+                        const isSelected = d.isSelected;
                         return (
-                          <TableCell key={`${d.id}_${c.key}`} size="small" title={typeof d[c.key] === 'string' ? (d[c.key] as string) : ''}>
+                          <TableCell
+                            key={`${d.id}_${c.key}`}
+                            size="small"
+                            title={typeof d[c.key] === 'string' ? (d[c.key] as string) : ''}
+                            style={isSelected ? { color: 'blue', fontWeight: 'bold', borderBottom: '2px solid #1976d2' } : {}}
+                          >
                             {d[c.key] !== undefined ? d[c.key] : ''}
                           </TableCell>
                         );

--- a/src/components/admin/dashboard-statistics/CountryActivityPhaseAccordion.tsx
+++ b/src/components/admin/dashboard-statistics/CountryActivityPhaseAccordion.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+
+import KeyboardDoubleArrowDownIcon from '@mui/icons-material/KeyboardDoubleArrowDown';
+import KeyboardDoubleArrowUpIcon from '@mui/icons-material/KeyboardDoubleArrowUp';
+
+import CountryActivityTable from './CountryActivityTable';
+
+interface Props {
+  phaseId: number;
+  countryCode: string;
+  open: boolean;
+  onClick: () => void;
+}
+
+const phaseLabels: Record<number, string> = {
+  1: 'Phase 1',
+  2: 'Phase 2',
+  3: 'Phase 3',
+};
+
+const CountryActivityPhaseAccordion: React.FC<Props> = ({ phaseId, countryCode, open, onClick }) => {
+  return (
+    <div style={{ marginTop: '1.5rem', borderRadius: 8, border: '1px solid #eee', background: '#fafbfc' }}>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          cursor: 'pointer',
+          padding: '1rem',
+          fontWeight: 600,
+          fontSize: 18,
+          borderBottom: open ? '1px solid #eee' : 'none',
+        }}
+        onClick={onClick}
+      >
+        <span>{phaseLabels[phaseId]}</span>
+        {open ? <KeyboardDoubleArrowUpIcon fontSize="large" /> : <KeyboardDoubleArrowDownIcon fontSize="large" />}
+      </div>
+      {open && (
+        <div style={{ padding: '1rem' }}>
+          <CountryActivityTable countryCode={countryCode} phaseId={phaseId} mode="country" />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CountryActivityPhaseAccordion;

--- a/src/components/admin/dashboard-statistics/CountryActivityTable.tsx
+++ b/src/components/admin/dashboard-statistics/CountryActivityTable.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+
+import { OneVillageTable } from '../OneVillageTable';
+import { CountryActivityTableHeaders, getCountryActivityTableHeaders } from './utils/tableHeaders';
+import { useCountryActivityTable } from 'src/services/useCountryActivityTable';
+import type { ClassroomActivity, PhaseDetail, CountryActivityMode } from 'src/services/useCountryActivityTable';
+
+interface CountryActivityTableProps {
+  countryCode: string;
+  phaseId: number;
+  mode?: CountryActivityMode;
+}
+
+type TableRow = {
+  id: string | number;
+  name: string;
+  totalPublications?: number;
+  commentCount?: number;
+  draftCount?: number;
+  mascotCount?: number;
+  videoCount?: number;
+  challengeCount?: number;
+  enigmaCount?: number;
+  gameCount?: number;
+  questionCount?: number;
+  reactionCount?: number;
+  reportingCount?: number;
+  storyCount?: number;
+  anthemCount?: number;
+  reinventStoryCount?: number;
+  isSelected?: boolean;
+  _highlight?: boolean;
+};
+
+const CountryActivityTable: React.FC<CountryActivityTableProps> = (props: CountryActivityTableProps) => {
+  const { countryCode, phaseId, mode = 'class' } = props;
+  const data = useCountryActivityTable(countryCode, phaseId, mode);
+
+  if (!data || data.length === 0) {
+    return <div>Aucune donnée disponible pour cette phase.</div>;
+  }
+
+  // On adapte les données pour le tableau (plat, phaseDetail à la racine)
+  const tableData: TableRow[] =
+    mode === 'country'
+      ? data.map((row: any, idx: number) => ({
+        ...row,
+        id: row.id || idx,
+        _highlight: row.isSelected,
+      }))
+      : (data as (ClassroomActivity & { phaseDetail?: PhaseDetail })[]).map((row, idx: number) => ({
+        id: row.classroomId || idx,
+        name: row.name,
+        totalPublications: row.totalPublications,
+        ...row.phaseDetail,
+        _highlight: true,
+      }));
+
+  const columns = mode === 'country' ? getCountryActivityTableHeaders(phaseId) : CountryActivityTableHeaders;
+
+  // Custom row style: bleu si _highlight
+  const rowStyle = (row: TableRow) => (row._highlight ? { color: '#1976d2', fontWeight: 600 } : {});
+
+  return (
+    <div style={{ margin: '0rem 0', overflowX: 'auto' }}>
+      <OneVillageTable admin={false} emptyPlaceholder={<p>Aucune donnée pour ce pays</p>} data={tableData} columns={columns} rowStyle={rowStyle} />
+    </div>
+  );
+};
+
+export default CountryActivityTable;

--- a/src/components/admin/dashboard-statistics/CountryActivityTable.tsx
+++ b/src/components/admin/dashboard-statistics/CountryActivityTable.tsx
@@ -44,17 +44,17 @@ const CountryActivityTable: React.FC<CountryActivityTableProps> = (props: Countr
   const tableData: TableRow[] =
     mode === 'country'
       ? data.map((row: any, idx: number) => ({
-        ...row,
-        id: row.id || idx,
-        _highlight: row.isSelected,
-      }))
+          ...row,
+          id: row.id || idx,
+          _highlight: row.isSelected,
+        }))
       : (data as (ClassroomActivity & { phaseDetail?: PhaseDetail })[]).map((row, idx: number) => ({
-        id: row.classroomId || idx,
-        name: row.name,
-        totalPublications: row.totalPublications,
-        ...row.phaseDetail,
-        _highlight: true,
-      }));
+          id: row.classroomId || idx,
+          name: row.name,
+          totalPublications: row.totalPublications,
+          ...row.phaseDetail,
+          _highlight: true,
+        }));
 
   const columns = mode === 'country' ? getCountryActivityTableHeaders(phaseId) : CountryActivityTableHeaders;
 
@@ -62,8 +62,15 @@ const CountryActivityTable: React.FC<CountryActivityTableProps> = (props: Countr
   const rowStyle = (row: TableRow) => (row._highlight ? { color: '#1976d2', fontWeight: 600 } : {});
 
   return (
-    <div style={{ margin: '0rem 0', overflowX: 'auto' }}>
-      <OneVillageTable admin={false} emptyPlaceholder={<p>Aucune donnée pour ce pays</p>} data={tableData} columns={columns} rowStyle={rowStyle} />
+    <div style={{ margin: '0rem 0', overflowX: 'auto', width: '100%' }}>
+      <OneVillageTable
+        admin={false}
+        emptyPlaceholder={<p>Aucune donnée pour ce pays</p>}
+        data={tableData}
+        columns={columns}
+        rowStyle={rowStyle}
+        tableLayout="auto"
+      />
     </div>
   );
 };

--- a/src/components/admin/dashboard-statistics/CountryStats.tsx
+++ b/src/components/admin/dashboard-statistics/CountryStats.tsx
@@ -51,7 +51,11 @@ const CountryStats = () => {
             <HorizontalBarsChart highlightCountry="FR"></HorizontalBarsChart>
           </div>
           <VillageListCard></VillageListCard>
-          <DashboardSummary data={{ ...statisticsSessions, ...statisticsClassrooms, ...statisticsFamily.data, barChartData: mockDataByMonth }} />
+          <DashboardSummary
+            data={{ ...statisticsSessions, ...statisticsClassrooms, ...statisticsFamily.data, barChartData: mockDataByMonth }}
+            selectedCountry={selectedCountry}
+            selectedPhase={selectedPhase}
+          />
         </>
       )}
     </>

--- a/src/components/admin/dashboard-statistics/dashboard-summary/DashboardClassroomTab.tsx
+++ b/src/components/admin/dashboard-statistics/dashboard-summary/DashboardClassroomTab.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import AccessTimeIcon from '@mui/icons-material/AccessTime';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import Grid from '@mui/material/Grid';
 
+import CountryActivityPhaseAccordion from '../CountryActivityPhaseAccordion';
 import AverageStatsCard from '../cards/AverageStatsCard/AverageStatsCard';
 import ClassesExchangesCard from '../cards/ClassesExchangesCard/ClassesExchangesCard';
 import StatsCard from '../cards/StatsCard/StatsCard';
@@ -29,9 +30,16 @@ const CONTRIBUTION_BAR_CHAR_TITLE = 'Contribution des classes';
 export interface DashboardClassroomTabProps {
   data: DashboardSummaryData;
   dashboardType: DashboardType;
+  selectedCountry?: string;
+  selectedPhase?: number;
 }
 
-const DashboardClassroomTab = ({ data, dashboardType }: DashboardClassroomTabProps) => {
+const DashboardClassroomTab = ({ data, dashboardType, selectedCountry, selectedPhase = 0 }: DashboardClassroomTabProps) => {
+  const [openPhases, setOpenPhases] = useState<Record<number, boolean>>({
+    1: false,
+    2: false,
+    3: false,
+  });
   return (
     <>
       <Grid container spacing={4} direction={{ xs: 'column', md: 'row' }}>
@@ -109,6 +117,39 @@ const DashboardClassroomTab = ({ data, dashboardType }: DashboardClassroomTabPro
             </div>
           </Grid>
         )}
+        {/* Accordéons par phase */}
+        {selectedCountry &&
+          (selectedPhase === 0 ? (
+            [1, 2, 3].map((phase) => (
+              <Grid item xs={12} lg={12} key={phase}>
+                <CountryActivityPhaseAccordion
+                  phaseId={phase}
+                  countryCode={selectedCountry}
+                  open={openPhases[phase]}
+                  onClick={() =>
+                    setOpenPhases((prev) => ({
+                      ...prev,
+                      [phase]: !prev[phase],
+                    }))
+                  }
+                />
+              </Grid>
+            ))
+          ) : (
+            <Grid item xs={12} lg={12}>
+              <CountryActivityPhaseAccordion
+                phaseId={selectedPhase}
+                countryCode={selectedCountry}
+                open={openPhases[selectedPhase]}
+                onClick={() =>
+                  setOpenPhases((prev) => ({
+                    ...prev,
+                    [selectedPhase]: !prev[selectedPhase],
+                  }))
+                }
+              />
+            </Grid>
+          ))}
       </Grid>
     </>
   );

--- a/src/components/admin/dashboard-statistics/dashboard-summary/DashboardSummary.tsx
+++ b/src/components/admin/dashboard-statistics/dashboard-summary/DashboardSummary.tsx
@@ -11,9 +11,11 @@ import type { DashboardSummaryData } from 'types/dashboard.type';
 interface DashboardSummaryProps {
   data: DashboardSummaryData;
   dashboardType?: DashboardType;
+  selectedCountry?: string;
+  selectedPhase?: number;
 }
 
-const DashboardSummary = ({ data, dashboardType = DashboardType.COMPLETE }: DashboardSummaryProps) => {
+const DashboardSummary = ({ data, dashboardType = DashboardType.COMPLETE, selectedCountry, selectedPhase }: DashboardSummaryProps) => {
   const [tabValue, setTabValue] = useState<DashboardSummaryTab>(DashboardSummaryTab.CLASSROOM);
 
   const handleTabChange = (_event: React.SyntheticEvent, newValue: DashboardSummaryTab) => {
@@ -31,7 +33,7 @@ const DashboardSummary = ({ data, dashboardType = DashboardType.COMPLETE }: Dash
         <Tab value={DashboardSummaryTab.FAMILY} label="En famille" />
       </Tabs>
       <TabPanel value={tabValue} index={DashboardSummaryTab.CLASSROOM}>
-        <DashboardClassroomTab data={data} dashboardType={dashboardType} />
+        <DashboardClassroomTab data={data} dashboardType={dashboardType} selectedCountry={selectedCountry} selectedPhase={selectedPhase} />
       </TabPanel>
       <TabPanel value={tabValue} index={DashboardSummaryTab.FAMILY}>
         <DashboardFamilyTab data={data} />

--- a/src/components/admin/dashboard-statistics/utils/tableHeaders.ts
+++ b/src/components/admin/dashboard-statistics/utils/tableHeaders.ts
@@ -12,3 +12,59 @@ export const FloatingAccountsHeaders = [
   { key: 'email', label: 'Mail', sortable: true },
   { key: 'creationDate', label: 'Date de création compte', sortable: true },
 ];
+
+export const CountryActivityTableHeaders = [
+  { key: 'name', label: 'Classe', sortable: true },
+  { key: 'totalPublications', label: 'Publications', sortable: true },
+  { key: 'commentCount', label: 'Commentaires', sortable: true },
+  { key: 'draftCount', label: 'Brouillons', sortable: true },
+  { key: 'mascotCount', label: 'Mascottes', sortable: true },
+  { key: 'videoCount', label: 'Vidéos', sortable: true },
+];
+
+export const CountryActivityTableCountryHeaders = [
+  { key: 'name', label: 'Nom du pays', sortable: true },
+  { key: 'mascotCount', label: 'Mascottes', sortable: true },
+  { key: 'videoCount', label: 'Vidéos', sortable: true },
+  { key: 'draftCount', label: 'Brouillons non publiés', sortable: true },
+  { key: 'commentCount', label: 'Commentaires', sortable: true },
+];
+
+export function getCountryActivityTableHeaders(phaseId: number) {
+  switch (phaseId) {
+    case 1:
+      return [
+        { key: 'name', label: 'Nom du pays', sortable: true },
+        { key: 'enigmaCount', label: 'Indices', sortable: true },
+        { key: 'mascotCount', label: 'Mascottes', sortable: true },
+        { key: 'videoCount', label: 'Vidéos', sortable: true },
+        { key: 'draftCount', label: 'Brouillons', sortable: true },
+        { key: 'commentCount', label: 'Commentaires', sortable: true },
+      ];
+    case 2:
+      return [
+        { key: 'name', label: 'Nom du pays', sortable: true },
+        { key: 'reportingCount', label: 'Reportages', sortable: true },
+        { key: 'challengeCount', label: 'Défis', sortable: true },
+        { key: 'enigmaCount', label: 'Énigmes', sortable: true },
+        { key: 'gameCount', label: 'Jeux', sortable: true },
+        { key: 'questionCount', label: 'Questions', sortable: true },
+        { key: 'reactionCount', label: 'Réactions', sortable: true },
+        { key: 'videoCount', label: 'Vidéos', sortable: true },
+        { key: 'commentCount', label: 'Commentaires', sortable: true },
+        { key: 'draftCount', label: 'Brouillons', sortable: true },
+      ];
+    case 3:
+      return [
+        { key: 'name', label: 'Nom du pays', sortable: true },
+        { key: 'anthemCount', label: 'Hymne', sortable: true },
+        { key: 'storyCount', label: 'Histoire', sortable: true },
+        { key: 'reinventStoryCount', label: 'Réécriture', sortable: true },
+        { key: 'videoCount', label: 'Vidéos', sortable: true },
+        { key: 'commentCount', label: 'Commentaires', sortable: true },
+        { key: 'draftCount', label: 'Brouillons', sortable: true },
+      ];
+    default:
+      return [];
+  }
+}

--- a/src/services/useCountryActivityTable.ts
+++ b/src/services/useCountryActivityTable.ts
@@ -1,0 +1,287 @@
+import { useMemo } from 'react';
+
+// TypeScript types pour coller au format backend fourni
+export type PhaseDetail = {
+  phaseId: number;
+  commentCount?: number;
+  draftCount?: number;
+  mascotCount?: number;
+  videoCount?: number;
+  challengeCount?: number;
+  enigmaCount?: number;
+  gameCount?: number;
+  questionCount?: number;
+  reactionCount?: number;
+  reportingCount?: number;
+  storyCount?: number;
+  anthemCount?: number;
+  reinventStoryCount?: number;
+};
+
+export type ClassroomActivity = {
+  name: string;
+  countryCode: string;
+  classroomId: string;
+  totalPublications: number;
+  phaseDetails: PhaseDetail[];
+};
+
+export type VillageActivity = {
+  villageName: string;
+  villageId: string;
+  countryCodes: string[];
+  classrooms: ClassroomActivity[];
+};
+
+// TODO: Fake data (à remplacer par un appel API plus tard)
+const MOCK_DATA: VillageActivity[] = [
+  {
+    villageName: 'France - Vietnam',
+    villageId: '123',
+    countryCodes: ['FR', 'VN'],
+    classrooms: [
+      {
+        name: 'École Marie-Renard',
+        countryCode: 'FR',
+        classroomId: '123',
+        totalPublications: 5,
+        phaseDetails: [
+          {
+            commentCount: 8,
+            draftCount: 3,
+            mascotCount: 1,
+            phaseId: 1,
+            videoCount: 0,
+          },
+          {
+            challengeCount: 0,
+            commentCount: 0,
+            draftCount: 0,
+            enigmaCount: 4,
+            gameCount: 0,
+            phaseId: 2,
+            questionCount: 0,
+            reactionCount: 0,
+            reportingCount: 0,
+            storyCount: 0,
+            videoCount: 0,
+          },
+          {
+            anthemCount: 0,
+            commentCount: 4,
+            draftCount: 0,
+            phaseId: 3,
+            reinventStoryCount: 0,
+            videoCount: 0,
+          },
+        ],
+      },
+      {
+        name: 'École Marie-Renard',
+        countryCode: 'FR',
+        classroomId: '123',
+        totalPublications: 5,
+        phaseDetails: [
+          {
+            commentCount: 6,
+            draftCount: 0,
+            mascotCount: 0,
+            phaseId: 1,
+            videoCount: 0,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    villageName: 'France - Espagne',
+    villageId: '123',
+    countryCodes: ['FR', 'ES'],
+    classrooms: [
+      {
+        name: 'École Marie-Renard',
+        countryCode: 'FR',
+        classroomId: '123',
+        totalPublications: 5,
+        phaseDetails: [
+          {
+            commentCount: 9,
+            draftCount: 0,
+            mascotCount: 0,
+            phaseId: 1,
+            videoCount: 0,
+          },
+        ],
+      },
+    ],
+  },
+];
+
+const COUNTRY_NAMES: Record<string, string> = {
+  FR: 'France',
+  VN: 'Vietnam',
+  ES: 'Espagne',
+  CA: 'Canada',
+  AR: 'Argentine',
+  BR: 'Brésil',
+  EC: 'Équateur',
+  IT: 'Italie',
+  JP: 'Japon',
+  LB: 'Liban',
+  MA: 'Maroc',
+  RO: 'Roumanie',
+  GB: 'Royaume-Uni',
+  RS: 'Serbie',
+  TN: 'Tunisie',
+  TR: 'Turquie',
+  // Ajoute d'autres pays si besoin
+};
+
+export type CountryActivityMode = 'country' | 'class';
+
+export function useCountryActivityTable(countryCode: string, phaseId: number, mode: CountryActivityMode = 'class') {
+  return useMemo(() => {
+    if (!phaseId) return [];
+    if (mode === 'country') {
+      const countryStats: Record<
+        string,
+        {
+          id: string;
+          name: string;
+          totalPublications: number;
+          commentCount: number;
+          draftCount: number;
+          mascotCount: number;
+          videoCount: number;
+          challengeCount: number;
+          enigmaCount: number;
+          gameCount: number;
+          questionCount: number;
+          reactionCount: number;
+          reportingCount: number;
+          storyCount: number;
+          anthemCount: number;
+          reinventStoryCount: number;
+          isSelected: boolean;
+        }
+      > = {};
+      for (const village of MOCK_DATA) {
+        for (const cc of village.countryCodes) {
+          const classes = village.classrooms.filter((c) => c.countryCode === cc);
+          // Pour chaque classe, on cherche la phase demandée
+          let totalPublications = 0;
+          let commentCount = 0;
+          let draftCount = 0;
+          let mascotCount = 0;
+          let videoCount = 0;
+          let challengeCount = 0;
+          let enigmaCount = 0;
+          let gameCount = 0;
+          let questionCount = 0;
+          let reactionCount = 0;
+          let reportingCount = 0;
+          let storyCount = 0;
+          let anthemCount = 0;
+          let reinventStoryCount = 0;
+          for (const c of classes) {
+            const phase = c.phaseDetails.find((p) => p.phaseId === phaseId);
+            totalPublications += c.totalPublications || 0;
+            if (phase) {
+              commentCount += phase.commentCount || 0;
+              draftCount += phase.draftCount || 0;
+              mascotCount += phase.mascotCount || 0;
+              videoCount += phase.videoCount || 0;
+              challengeCount += phase.challengeCount || 0;
+              enigmaCount += phase.enigmaCount || 0;
+              gameCount += phase.gameCount || 0;
+              questionCount += phase.questionCount || 0;
+              reactionCount += phase.reactionCount || 0;
+              reportingCount += phase.reportingCount || 0;
+              storyCount += phase.storyCount || 0;
+              anthemCount += phase.anthemCount || 0;
+              reinventStoryCount += phase.reinventStoryCount || 0;
+            }
+          }
+          if (!countryStats[cc]) {
+            countryStats[cc] = {
+              id: cc,
+              name: COUNTRY_NAMES[cc] || cc,
+              totalPublications: 0,
+              commentCount: 0,
+              draftCount: 0,
+              mascotCount: 0,
+              videoCount: 0,
+              challengeCount: 0,
+              enigmaCount: 0,
+              gameCount: 0,
+              questionCount: 0,
+              reactionCount: 0,
+              reportingCount: 0,
+              storyCount: 0,
+              anthemCount: 0,
+              reinventStoryCount: 0,
+              isSelected: false,
+            };
+          }
+          countryStats[cc].totalPublications += totalPublications;
+          countryStats[cc].commentCount += commentCount;
+          countryStats[cc].draftCount += draftCount;
+          countryStats[cc].mascotCount += mascotCount;
+          countryStats[cc].videoCount += videoCount;
+          countryStats[cc].challengeCount += challengeCount;
+          countryStats[cc].enigmaCount += enigmaCount;
+          countryStats[cc].gameCount += gameCount;
+          countryStats[cc].questionCount += questionCount;
+          countryStats[cc].reactionCount += reactionCount;
+          countryStats[cc].reportingCount += reportingCount;
+          countryStats[cc].storyCount += storyCount;
+          countryStats[cc].anthemCount += anthemCount;
+          countryStats[cc].reinventStoryCount += reinventStoryCount;
+        }
+      }
+      let rows = Object.values(countryStats);
+      // Ajoute le pays sélectionné si absent
+      if (countryCode && !countryStats[countryCode]) {
+        rows = [
+          {
+            id: countryCode,
+            name: COUNTRY_NAMES[countryCode] || countryCode,
+            totalPublications: 0,
+            commentCount: 0,
+            draftCount: 0,
+            mascotCount: 0,
+            videoCount: 0,
+            challengeCount: 0,
+            enigmaCount: 0,
+            gameCount: 0,
+            questionCount: 0,
+            reactionCount: 0,
+            reportingCount: 0,
+            storyCount: 0,
+            anthemCount: 0,
+            reinventStoryCount: 0,
+            isSelected: true,
+          },
+          ...rows,
+        ];
+      } else if (countryCode) {
+        rows = rows.map((row) => (row.id === countryCode ? { ...row, isSelected: true } : row));
+        // Trie pour mettre le pays sélectionné en premier
+        rows = rows.sort((a, b) => (a.id === countryCode ? -1 : b.id === countryCode ? 1 : 0));
+      }
+      return rows;
+    } else {
+      // mode 'class' (comportement actuel)
+      if (!countryCode) return [];
+      const villages = MOCK_DATA.filter((v) => v.countryCodes.includes(countryCode));
+      const classrooms = villages.flatMap((v) => v.classrooms.filter((c) => c.countryCode === countryCode));
+      return classrooms.map((c) => {
+        const phase = c.phaseDetails.find((p) => p.phaseId === phaseId);
+        return {
+          ...c,
+          phaseDetail: phase,
+        };
+      });
+    }
+  }, [countryCode, phaseId, mode]);
+}


### PR DESCRIPTION
 Hook useCountryActivityTable

- [x] Création d'un hook personnalisé pour gérer les données d'activité par pays
- [x] Données mockées en format backend pour faciliter l'intégration future

Composant CountryActivityTable

- [x] Tableau générique utilisant OneVillageTable pour l'affichage
- [x] Headers dynamiques selon la phase sélectionnée
- [x] Mise en évidence du pays sélectionné (texte bleu + bordure)
- [x] Placement automatique du pays sélectionné en première position

Composant CountryActivityPhaseAccordion

- [x] Accordéon pour chaque phase avec icônes double-flèche
- [x] Gestion de l'état ouvert/fermé contrôlée par le parent
- [x] Gestion de l'état des accordéons avec openPhases
- [x] Support du filtrage par phase (affichage d'une seule phase ou toutes)

🎨 Interface utilisateur

Design cohérent :

- [x] Accordéons avec bordures et fond gris clair
- [x] Icônes double-flèche pour l'ouverture/fermeture
- [x] Mise en évidence du pays sélectionné en bleu
- [x] Espacement et padding cohérents avec le design existant

Expérience utilisateur :

- [x] Filtrage par phase fonctionnel
- [x] Accordéons indépendants (pas de fermeture automatique)
- [x] État par défaut : tous fermés
- [x] Navigation intuitive entre les phases


How to test : 

- Go to dashboard admin
- Go to Analyze
- Go to Onglet Pays
- choose a country ( eg. France )
- Check if 3 tables about phases are displayed and containg good and fiable data.
- Choose a phase
- Check if 1 table about the selected phase is displayed
