### PR TITLE
chore(ci-cd): upgrade CodeQL version

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,7 +39,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -48,4 +48,4 @@ jobs:
           # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
CodeQL v1 est déprécié depuis le 18 janvier 2023.
Passage à la version 2 comme mentionné dans la documentation : 
- [Doc CodeQL GitHub v1 -> v2](https://github.blog/changelog/2023-01-18-code-scanning-codeql-action-v1-is-now-deprecated/ ) 
- [Doc CodeQL GitHub v2 -> v3](https://github.blog/changelog/2025-01-10-code-scanning-codeql-action-v2-is-now-deprecated/)


<img width="1126" alt="image" src="https://github.com/user-attachments/assets/4baff50e-f36e-497c-89a0-c7e3aa86a32d" />