### PR TITLE
chore(ci-cd): add mergeConfidence to Renovate and move file to .github/

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,7 @@
+{
+  "extends": [
+    "config:base",
+    "mergeConfidence:all-badges"
+  ],
+  "prConcurrentLimit": 5
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "extends": [
-    "config:base"
-  ],
-  "prConcurrentLimit": 5
-}


### PR DESCRIPTION
- Déplacement du fichier de configuration Renovate dans .github/ pour rassembler ce qui concerne la CI/CD
- ajouter du paramètre "mergeConfidence" qui permet d'avoir des "pourcentages de confiance" dans la mise à jour d'une dépendance