### PR TITLE
fix(VIL-739): change to publish date in activity view

### DIFF
--- a/src/components/accueil/LastActivities.tsx
+++ b/src/components/accueil/LastActivities.tsx
@@ -39,7 +39,7 @@ export const LastActivities: React.FC<Props> = ({ title, activityUser }) => {
               <>
                 <div style={{ fontSize: 'smaller', paddingBottom: '1rem' }}>
                   <strong>{DESC[activity.type]},&nbsp;</strong>
-                  le {toDate(activity.createDate as string)}
+                  le {toDate(activity.publishDate as string)}
                   {ActivityIcon && (
                     <ActivityIcon
                       style={{

--- a/src/components/activities/ActivityView/index.tsx
+++ b/src/components/activities/ActivityView/index.tsx
@@ -50,7 +50,7 @@ export const ActivityView = ({ activity, user }: ActivityViewProps) => {
                 <UserDisplayName user={user} activity={activity} displayAsUser={activity.displayAsUser} />
               </h2>
               <div style={{ display: 'flex', alignItems: 'center' }}>
-                <p className="text text--small">Publié le {toDate(activity.createDate as string)} </p>
+                <p className="text text--small">Publié le {toDate(activity.publishDate as string)} </p>
                 {isPelico ? (
                   <PelicoNeutre style={{ marginLeft: '0.6rem', height: '16px', width: 'auto' }} />
                 ) : (


### PR DESCRIPTION
### Motivation

https://parlemonde.atlassian.net/browse/VIL-739

### Changes

Utiliser la bonne propriété de l'activité `publishDate` au lieu de `createDate`

### Test

Avant le test, chercher une activité avec une date de création et de publication différente.
Modifier une activité en base de données si nécessaire.
Aller sur cette activité et vérifier si la date est bonne.

<img width="871" height="428" alt="image" src="https://github.com/user-attachments/assets/fd92a84d-847a-4d23-96af-b368c99fe23a" />

