### PR TITLE
feat(VIL-793): show deblock, analyse and delete user buttons according to user type

### DIFF
--- a/src/pages/admin/newportal/manage/users/index.tsx
+++ b/src/pages/admin/newportal/manage/users/index.tsx
@@ -39,6 +39,8 @@ const Users = () => {
   const { deleteUser } = useUserRequests();
   const [deleteIndex, setDeleteIndex] = React.useState(-1);
 
+  const userIsAdminOrSad = Boolean(user && (user.type === UserType.SUPER_ADMIN || user.type === UserType.ADMIN));
+
   const TABLE_ENTRIES_BY_PAGE = 5;
 
   const filteredUsers = useMemo(
@@ -139,10 +141,10 @@ const Users = () => {
       >
         Modifier
       </MenuItem>
-      <MenuItem aria-label="analyse" onClick={() => {}} disabled>
+      <MenuItem aria-label="analyse" disabled>
         Analyser
       </MenuItem>
-      <MenuItem aria-label="unblock" onClick={() => {}} disabled>
+      <MenuItem aria-label="unblock" disabled>
         Débloquer
       </MenuItem>
       <MenuItem
@@ -150,6 +152,7 @@ const Users = () => {
         onClick={() => {
           setDeleteIndex(users.findIndex((u) => u.id === id));
         }}
+        disabled={!userIsAdminOrSad}
       >
         Supprimer
       </MenuItem>
@@ -167,8 +170,7 @@ const Users = () => {
       <AdminTile
         title="Il y a ici la liste complète des utilisateurs de 1Village"
         toolbarButton={
-          user &&
-          (user.type === UserType.SUPER_ADMIN || user.type === UserType.ADMIN) && (
+          userIsAdminOrSad && (
             <Box style={{ display: 'flex', gap: '12px', justifyContent: 'flex-end', margin: '16px 0' }}>
               <Button className="like-button blue" component="a" onClick={handleExportToCSV} disabled={filteredUsers.length === 0}>
                 Exporter en CSV

--- a/src/pages/admin/newportal/manage/users/index.tsx
+++ b/src/pages/admin/newportal/manage/users/index.tsx
@@ -39,7 +39,8 @@ const Users = () => {
   const { deleteUser } = useUserRequests();
   const [deleteIndex, setDeleteIndex] = React.useState(-1);
 
-  const userIsAdminOrSad = Boolean(user && (user.type === UserType.SUPER_ADMIN || user.type === UserType.ADMIN));
+  const userIsAdminOrSad = !!(user && [UserType.SUPER_ADMIN, UserType.ADMIN].includes(user.type));
+  const userIsAdminSadOrMediator = !!(user && [UserType.SUPER_ADMIN, UserType.ADMIN, UserType.MEDIATOR].includes(user.type));
 
   const TABLE_ENTRIES_BY_PAGE = 5;
 
@@ -141,21 +142,20 @@ const Users = () => {
       >
         Modifier
       </MenuItem>
-      <MenuItem aria-label="analyse" disabled>
-        Analyser
-      </MenuItem>
-      <MenuItem aria-label="unblock" disabled>
-        Débloquer
-      </MenuItem>
-      <MenuItem
-        aria-label="delete"
-        onClick={() => {
-          setDeleteIndex(users.findIndex((u) => u.id === id));
-        }}
-        disabled={!userIsAdminOrSad}
-      >
-        Supprimer
-      </MenuItem>
+      {userIsAdminSadOrMediator && <MenuItem aria-label="analyse">Analyser</MenuItem>}
+      {userIsAdminOrSad && (
+        <>
+          <MenuItem aria-label="unblock">Débloquer</MenuItem>
+          <MenuItem
+            aria-label="delete"
+            onClick={() => {
+              setDeleteIndex(users.findIndex((u) => u.id === id));
+            }}
+          >
+            Supprimer
+          </MenuItem>
+        </>
+      )}
     </OneVillageTableActionMenu>
   );
 


### PR DESCRIPTION
### Motivation

Ticket Jira : [VIL-793](https://parlemonde.atlassian.net/browse/VIL-793)

### Changes

Affichage des boutons d'actions admin sur les utilisateurs en fonction du type de l'utilisateur en session.

### Test

Sur la page d'administration des utilisateurs, vérifier que  : 
- les admins et SAD voient les boutons Modifier, Analyser, Débloquer et Supprimer.
- les admins, SAD et médiateurs voient les boutons Modifier et Analyser.
- les autres utilisateurs ayant accès à la page ne voient que le bouton Modifier.
