### PR TITLE
feat(VIL-794): déplace les données mockées de la carte dans GlobalStats et ajoute les loaders

### DIFF
--- a/src/components/admin/dashboard-statistics/ActivityTable.tsx
+++ b/src/components/admin/dashboard-statistics/ActivityTable.tsx
@@ -1,99 +1,42 @@
-import React from 'react';
+import type { JSX } from 'react';
 
 import { Box } from '@mui/material';
 
 import { OneVillageTable } from '../OneVillageTable';
 import { countryToFlag } from 'src/utils';
+import type { VillageInteractionsActivity } from 'types/analytics/village-interactions-activity';
+import { VillageInteractionsStatus } from 'types/analytics/village-interactions-activity';
 import type { Country } from 'types/country.type';
 
-type CountryStatus = 'active' | 'observer' | 'ghost' | 'absent';
+type FormatedVillageActivity = {
+  countries: string;
+  status: JSX.Element;
+  id: number;
+  totalConnections: number;
+  totalActivities: number;
+};
 
 const countriesToText = (countries: Country[]) => {
   return countries.map((c) => `${countryToFlag(c.isoCode)} ${c.name}`).join(' - ');
 };
 
-const getCountryColor = (status: CountryStatus) => {
+const getCountryColor = (status: VillageInteractionsStatus) => {
   switch (status) {
-    case 'active':
+    case VillageInteractionsStatus.ACTIVE:
       return '#4CC64A';
-    case 'observer':
+    case VillageInteractionsStatus.OBSERVER:
       return '#6082FC';
-    case 'ghost':
+    case VillageInteractionsStatus.GHOST:
       return '#FFD678';
-    case 'absent':
+    case VillageInteractionsStatus.ABSENT:
       return '#D11818';
     default:
       return '#FFF';
   }
 };
 
-// Même structure de données que dans la table villages-mondes (manage/villages)
-
-const fakeData = [
-  {
-    id: 1,
-    countries: [
-      {
-        isoCode: 'FR',
-        name: 'France',
-      },
-      {
-        isoCode: 'LU',
-        name: 'Luxembourg',
-      },
-    ],
-    totalConnections: 240,
-    totalActivities: 853,
-    status: 'active',
-  },
-  {
-    id: 2,
-    countries: [
-      {
-        isoCode: 'FR',
-        name: 'France',
-      },
-      {
-        isoCode: 'US',
-        name: 'United States',
-      },
-    ],
-    totalConnections: 35,
-    totalActivities: 140,
-    status: 'observer',
-  },
-  {
-    id: 3,
-    countries: [
-      {
-        isoCode: 'FR',
-        name: 'France',
-      },
-      {
-        isoCode: 'GB',
-        name: 'United Kingdom',
-      },
-    ],
-    totalConnections: 56,
-    totalActivities: 593,
-    status: 'ghost',
-  },
-];
-
-// On prépare les données déjà formatées pour l'affichage
-const tableData = fakeData.map((row) => {
-  return {
-    ...row,
-    countries: countriesToText(row.countries),
-    status: (
-      <span key={row.status} style={{ color: getCountryColor(row.status as CountryStatus), fontSize: 24 }}>
-        ●
-      </span>
-    ),
-  };
-});
-
-const ActivityTable = () => {
+const ActivityTable = ({ activityTableData }: { activityTableData: VillageInteractionsActivity[] }) => {
+  const tableData = formatVillagesData(activityTableData);
   return (
     <Box sx={{ overflow: 'auto', marginTop: 2 }}>
       <OneVillageTable
@@ -113,3 +56,15 @@ const ActivityTable = () => {
 };
 
 export default ActivityTable;
+
+function formatVillagesData(activityData: VillageInteractionsActivity[]): FormatedVillageActivity[] {
+  return activityData.map((villageActivity) => ({
+    ...villageActivity,
+    countries: countriesToText(villageActivity.countries),
+    status: (
+      <span key={villageActivity.status} style={{ color: getCountryColor(villageActivity.status), fontSize: 24 }}>
+        ●
+      </span>
+    ),
+  }));
+}

--- a/src/components/admin/dashboard-statistics/GlobalStats.tsx
+++ b/src/components/admin/dashboard-statistics/GlobalStats.tsx
@@ -1,7 +1,7 @@
-import React, { useState } from 'react';
+import { useEffect, useState } from 'react';
 
-import { TeamCommentType } from '../../../../types/teamComment.type';
 import ActivityTable from './ActivityTable';
+import Loader, { AnalyticsDataType } from './Loader';
 import TeamCommentCard from './TeamCommentCard';
 import DashboardSummary from './dashboard-summary/DashboardSummary';
 import StatisticFilters from './filters/StatisticFilters';
@@ -9,27 +9,104 @@ import DashboardWorldMap from './map/DashboardWorldMap/DashboardWorldMap';
 import { mockDataByMonth } from './mocks/mocks';
 import { useGetOneVillageStats, useGetSessionsStats } from 'src/api/statistics/statistics.get';
 import { useStatisticsClassrooms } from 'src/services/useStatistics';
+import type { VillageInteractionsActivity } from 'types/analytics/village-interactions-activity';
+import { VillageInteractionsStatus } from 'types/analytics/village-interactions-activity';
 import { DashboardType } from 'types/dashboard.type';
 import type { ClassroomsStats } from 'types/statistics.type';
+import { TeamCommentType } from 'types/teamComment.type';
 
 const GlobalStats = () => {
   const [selectedPhase, setSelectedPhase] = useState<number>();
   const classroomStatistics = useStatisticsClassrooms(null, null, null) as ClassroomsStats;
 
-  const { data: sessionStatistics } = useGetSessionsStats(selectedPhase);
-  const { data: oneVillageStatistics } = useGetOneVillageStats();
+  const [mapData, setMapData] = useState<VillageInteractionsActivity[]>([]);
+  const [loadingMapData, setLoadingMapData] = useState<boolean>(true);
+
+  const { data: sessionStatistics, isLoading: isLoadingSessionStats } = useGetSessionsStats(selectedPhase);
+  const { data: oneVillageStatistics, isLoading: isLoadingWebsiteStats } = useGetOneVillageStats();
+
+  // On mocke l'asynchronisme en attendant d'avoir l'appel serveur censé retourner les interactions des villages-mondes
+  // A refacto lors de l'implémentation du ticket VIL-10: Planisphère représentant l'activité d'1V
+  useEffect(() => {
+    setTimeout(() => {
+      const fakeAnalyticsData: VillageInteractionsActivity[] = [
+        {
+          id: 1,
+          countries: [
+            {
+              isoCode: 'FR',
+              name: 'France',
+            },
+            {
+              isoCode: 'LU',
+              name: 'Luxembourg',
+            },
+          ],
+          totalConnections: 240,
+          totalActivities: 853,
+          status: VillageInteractionsStatus.ACTIVE,
+        },
+        {
+          id: 2,
+          countries: [
+            {
+              isoCode: 'FR',
+              name: 'France',
+            },
+            {
+              isoCode: 'US',
+              name: 'United States',
+            },
+          ],
+          totalConnections: 35,
+          totalActivities: 140,
+          status: VillageInteractionsStatus.OBSERVER,
+        },
+        {
+          id: 3,
+          countries: [
+            {
+              isoCode: 'FR',
+              name: 'France',
+            },
+            {
+              isoCode: 'GB',
+              name: 'United Kingdom',
+            },
+          ],
+          totalConnections: 56,
+          totalActivities: 593,
+          status: VillageInteractionsStatus.GHOST,
+        },
+      ];
+
+      setMapData(fakeAnalyticsData);
+      setLoadingMapData(false);
+    }, 2000);
+  }, []);
 
   return (
     <>
       <TeamCommentCard type={TeamCommentType.GLOBAL} />
       <StatisticFilters onPhaseChange={setSelectedPhase} />
-      <DashboardWorldMap />
-      <ActivityTable />
-      {sessionStatistics && oneVillageStatistics && (
-        <DashboardSummary
-          dashboardType={DashboardType.ONE_VILLAGE_PANEL}
-          data={{ ...classroomStatistics, ...sessionStatistics, ...oneVillageStatistics, barChartData: mockDataByMonth }}
-        />
+      {loadingMapData ? (
+        <Loader analyticsDataType={AnalyticsDataType.GRAPHS} />
+      ) : (
+        <>
+          <DashboardWorldMap />
+          <ActivityTable activityTableData={mapData} />
+        </>
+      )}
+      {isLoadingSessionStats || isLoadingWebsiteStats ? (
+        <Loader analyticsDataType={AnalyticsDataType.WIDGETS} />
+      ) : (
+        sessionStatistics &&
+        oneVillageStatistics && (
+          <DashboardSummary
+            dashboardType={DashboardType.ONE_VILLAGE_PANEL}
+            data={{ ...classroomStatistics, ...sessionStatistics, ...oneVillageStatistics, barChartData: mockDataByMonth }}
+          />
+        )
       )}
     </>
   );

--- a/src/components/admin/dashboard-statistics/Loader.tsx
+++ b/src/components/admin/dashboard-statistics/Loader.tsx
@@ -1,0 +1,29 @@
+import { CircularProgress } from '@mui/material';
+
+export enum AnalyticsDataType {
+  GRAPHS = 'GRAPHS',
+  WIDGETS = 'WIDGETS',
+}
+
+const Loader = ({ analyticsDataType }: { analyticsDataType: AnalyticsDataType }) => {
+  return (
+    <div
+      style={{
+        height: '4.5rem',
+        margin: '6rem 21.5rem',
+        padding: '0.75rem',
+        display: 'flex',
+        justifyContent: 'space-between',
+      }}
+    >
+      <CircularProgress />
+      <p style={{ margin: 0, padding: '0.4rem 0 0.6rem', fontSize: '1.3rem' }}>{getLoaderLegend(analyticsDataType)}...</p>
+    </div>
+  );
+};
+
+export default Loader;
+
+function getLoaderLegend(analyticsDataType: AnalyticsDataType): string {
+  return analyticsDataType === AnalyticsDataType.GRAPHS ? 'Chargement des visuels' : 'Chargement des données';
+}

--- a/types/analytics/village-interactions-activity.ts
+++ b/types/analytics/village-interactions-activity.ts
@@ -1,0 +1,16 @@
+import type { Country } from '../country.type';
+
+export interface VillageInteractionsActivity {
+  id: number;
+  countries: Country[];
+  totalConnections: number;
+  totalActivities: number;
+  status: VillageInteractionsStatus;
+}
+
+export enum VillageInteractionsStatus {
+  ACTIVE = 'active',
+  OBSERVER = 'observer',
+  GHOST = 'ghost',
+  ABSENT = 'absent',
+}


### PR DESCRIPTION
### Motivation

Ticket Jira : [VIL-794](https://parlemonde.atlassian.net/browse/VIL-794)

### Changes

- Moves the creation of mocked data in the parent component
- Adds loaders for the top and bottom parts of the tab

### Test

Verify that the loaders appear while the data is being retrieved using a backend request or using a timeout function to mock the asynchronism of a backend request
