### PR TITLE
feat(VIL-799): add loaders on classe statistics page

### DIFF
--- a/src/components/admin/dashboard-statistics/cards/ClassroomDetailsCard/ClassroomDetailsCard.tsx
+++ b/src/components/admin/dashboard-statistics/cards/ClassroomDetailsCard/ClassroomDetailsCard.tsx
@@ -3,7 +3,11 @@ import React from 'react';
 import CountryMap from '../../map/CountryMap/CountryMap';
 import styles from './ClassroomDetailsCard.module.css';
 
-const ClassroomDetailsCard = () => {
+interface ClassroomDetailsCardProps {
+  classroomDetails: string;
+}
+
+const ClassroomDetailsCard = ({ classroomDetails }: ClassroomDetailsCardProps) => {
   return (
     <div className={styles.mainContainer}>
       <CountryMap countryIso2="VN" />
@@ -11,7 +15,7 @@ const ClassroomDetailsCard = () => {
         <h1>Ecole</h1>
         <ul>
           <li>Adresse</li>
-          <li>Pays: </li>
+          <li>Pays: {classroomDetails}</li>
           <li>Village Monde: </li>
           <li>Adresse Mail: </li>
           <li>Dernière connexion: </li>


### PR DESCRIPTION
### Motivation

Ticket Jira : [VIL-799](https://parlemonde.atlassian.net/browse/VIL-799)

### Changes

- Adds loaders for the top and bottom parts of the tab

### Test

Verify that the loaders appear while the data is being retrieved using a backend request or using a timeout function to mock the asynchronism of a backend request