### PR TITLE
fix(VIL-640): fix state conflict with h5p between staging and prod

### DIFF
--- a/server/h5p/lib/AwsContentStorage.ts
+++ b/server/h5p/lib/AwsContentStorage.ts
@@ -9,7 +9,7 @@ import { logger } from '../../utils/logger';
 import { validateFilename } from './S3Util';
 import { dynamoDb } from './dynamoDB';
 
-const CONTENT_TABLE_NAME = 'H5P_Content';
+const CONTENT_TABLE_NAME = `${process.env.ENV || 'dev'}_H5P_Content`;
 
 export class AwsContentStorage implements IContentStorage {
   constructor() {}

--- a/server/h5p/lib/AwsContentUserDataStorage.ts
+++ b/server/h5p/lib/AwsContentUserDataStorage.ts
@@ -3,8 +3,8 @@ import { H5pError } from '@lumieducation/h5p-server';
 
 import { dynamoDb } from './dynamoDB';
 
-const USER_DATA_TABLE = 'H5P_user-data-content';
-const FINISHED_DATA_TABLE = 'H5P_finished-data';
+const USER_DATA_TABLE = `${process.env.ENV || 'dev'}_H5P_user-data-content`;
+const FINISHED_DATA_TABLE = `${process.env.ENV || 'dev'}_H5P_finished-data`;
 
 export class AwsContentUserDataStorage implements IContentUserDataStorage {
   constructor() {}

--- a/server/h5p/lib/AwsKeyValueStorage.ts
+++ b/server/h5p/lib/AwsKeyValueStorage.ts
@@ -3,7 +3,11 @@ import { H5pError } from '@lumieducation/h5p-server';
 
 import { dynamoDb } from './dynamoDB';
 
-const DATA_TABLE_NAME = 'H5P_Data';
+if (!process.env.ENV) {
+  console.warn('ENV is not set, using "dev" as default environment name');
+}
+
+const DATA_TABLE_NAME = `${process.env.ENV || 'dev'}_H5P_Data`;
 
 export class AwsKeyValueStorage implements IKeyValueStorage {
   constructor() {}

--- a/server/h5p/lib/AwsLibraryStorage.ts
+++ b/server/h5p/lib/AwsLibraryStorage.ts
@@ -17,7 +17,7 @@ import { logger } from '../../utils/logger';
 import { validateFilename } from './S3Util';
 import { dynamoDb } from './dynamoDB';
 
-const LIBRARY_TABLE_NAME = 'H5P_libraries';
+const LIBRARY_TABLE_NAME = `${process.env.ENV || 'dev'}_H5P_libraries`;
 
 type LibraryDep = {
   dynamicDependencies: ILibraryName[];


### PR DESCRIPTION
### Motivation

https://parlemonde.atlassian.net/browse/VIL-640

Les tables utilisées pour H5P sont les mêmes entre la prod et staging.
Ça serait responsable du conflit d'état du contenu H5P.

### Changes

Changement des noms de table DynamoDB qui concernent H5P
Préfixer par le nom d'environnement

### Test

Voir vidéo dans le ticket Jira
