### PR TITLE
fix(VIL): corrige la gestion des nouvelles sessions

### DIFF
--- a/src/contexts/userContext.tsx
+++ b/src/contexts/userContext.tsx
@@ -2,6 +2,7 @@ import { useRouter } from 'next/router';
 import React from 'react';
 import type { Classroom } from 'server/entities/classroom';
 
+import { resetSessionId, saveNewSessionAnalytic } from 'src/hooks/useAnalytics';
 import { axiosRequest } from 'src/utils/axiosRequest';
 import type { Student } from 'types/student.type';
 import type { User, UserForm } from 'types/user.type';
@@ -118,7 +119,10 @@ export const UserContextProvider = ({ user, setUser, children }: React.PropsWith
       setUser(response.data.user || null);
       if (response.data.user) {
         getClassroom(response.data.user.id);
+
+        await saveNewSessionAnalytic(response.data.user.id);
       }
+
       return {
         success: true,
         errorCode: 0,
@@ -163,6 +167,7 @@ export const UserContextProvider = ({ user, setUser, children }: React.PropsWith
       baseURL: '',
     });
     setUser(null);
+    resetSessionId();
     router.push('/');
   }, [router, setUser]);
 


### PR DESCRIPTION
### Motivation

Les sessions étaient créées et sauvegardées à chaque nouvel onglet, même si l'utilisateur n'était pas encore connecté

### Changes

Nouveaux comportements :

- La session est créée quand l'utilisateur se connecte et on y stocke les mêmes infos qu'avant + le bon id
- Si l'utilisateur ouvre un autre onglet et que des identifiants de session n'ont pas expiré on garde la même session (notamment pour les données des pages consultées)
- Si l'utilisateur se déconnecte la session reste dans la base de données mais s'il se reconnecte juste après, ce sera une nouvelle session (on considère que la précédente est expirée)
- Si un autre utilisateur se connecte après le premier, on a bien une nouvelle session avec le nouvel identifient (celui du deuxième)

### Test

Vérifier que le comportement actuel correspond bien au comportement attendu (précisé précédemment mais surtout attendu par le métier).
