### PR TITLE
feat(VIL-727): Hide the option to react to activities in phase 3

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -172,7 +172,7 @@ export const Navigation = (): JSX.Element => {
         phase: 2,
         disabled: isParent,
       },
-      /* VIL-727: invisibiliser sans supprimer la fonctionalité
+      /* 
       {
         label: 'Réagir à une activité',
         path: '/reagir-a-une-activite/1',

--- a/src/components/activities/ActivityComments/AddComment.tsx
+++ b/src/components/activities/ActivityComments/AddComment.tsx
@@ -130,7 +130,6 @@ export const AddComment = ({ activityId, activityType, activityPhase }: AddComme
           </Box>
         </div>
         {activityPhase == 2 && activityType !== ActivityType.REACTION && (
-          /* VIL-727: garder la section de "réagir / ré-écrire" uniquement pour la phase 2 */
           <Box
             sx={{
               marginLeft: {


### PR DESCRIPTION
### Motivation

https://parlemonde.atlassian.net/browse/VIL-727

### Changes

- Invisibilisation de la fonctionnalité "Réagir à une activité" de la barre de navigation en phase 2
- Retrait de la possibilité de réagir / ré-inventer une histoire sur tous les commentaires de phase 3  

### Test

- Aller sur l'accueil -> phase 2, et constater l'absence de "Réagir à une activité" dans la barre de navigation
- Aller dans le détail des activités de la phase 3, et constater qu'il n'y a plus la possibilité de réagir / ré-inventer une histoire
