### PR TITLE
feat/VIL-63: add village-monde section in Country panel

### DIFF
--- a/src/api/statistics/statistics.get.ts
+++ b/src/api/statistics/statistics.get.ts
@@ -11,6 +11,7 @@ import type {
   EngagementStatus,
   CountryEngagementStatus,
 } from 'types/statistics.type';
+import type { Village } from 'types/village.type';
 
 async function getSessionsStats(phase?: number): Promise<SessionsStats> {
   return (
@@ -41,6 +42,22 @@ async function getVillagesStats(villageId?: number, phase?: number): Promise<Vil
     })
   ).data;
 }
+
+async function getVillages(countryIsoCode?: string): Promise<Village[]> {
+  return (
+    await axiosRequest({
+      method: 'GET',
+      baseURL: '/api',
+      url: countryIsoCode ? `/villages?countryIsoCode=${countryIsoCode}` : '/villages',
+    })
+  ).data;
+}
+
+export const useGetVillages = (countryIsoCode?: string) => {
+  return useQuery(['villages', countryIsoCode], () => getVillages(countryIsoCode), {
+    enabled: !!countryIsoCode,
+  });
+};
 
 async function getCountriesStats(countryId?: string, phase?: number): Promise<VillageStats> {
   return (

--- a/src/components/admin/dashboard-statistics/CountryStats.tsx
+++ b/src/components/admin/dashboard-statistics/CountryStats.tsx
@@ -12,13 +12,22 @@ import StatisticFilters from './filters/StatisticFilters';
 import { mockDataByMonth } from './mocks/mocks';
 import { PelicoCard } from './pelico-card';
 import styles from './styles/charts.module.css';
-import { useGetClassroomsEngagementStatus, useGetCountriesStats, useGetCountryEngagementStatus } from 'src/api/statistics/statistics.get';
+import {
+  useGetClassroomsEngagementStatus,
+  useGetCountriesStats,
+  useGetCountryEngagementStatus,
+  useGetVillages,
+} from 'src/api/statistics/statistics.get';
 import { useStatisticsClassrooms, useStatisticsSessions } from 'src/services/useStatistics';
 import type { CountryStat } from 'types/analytics/country-stat';
-import type { VillageListItem } from 'types/analytics/village-list-item';
 import { TeamCommentType } from 'types/teamComment.type';
 
-const CountryStats = () => {
+interface CountryStatsProps {
+  onVillageSelect?: (villageId: number, selectedCountry?: string) => void;
+}
+
+// eslint-disable-next-line react/prop-types
+const CountryStats: React.FC<CountryStatsProps> = ({ onVillageSelect }) => {
   const [selectedPhase, setSelectedPhase] = useState<number>();
   const [selectedCountry, setSelectedCountry] = useState<string>();
 
@@ -26,8 +35,6 @@ const CountryStats = () => {
   const [loadingHighlightedCountry, setLoadingHighlightedCountry] = useState<boolean>(true);
   const [barsChartData, setBarsChartData] = useState<CountryStat[]>([]);
   const [loadingBarsChartData, setLoadingBarsChartData] = useState<boolean>(true);
-  const [villageList, setVillageList] = useState<VillageListItem[]>([]);
-  const [loadingVillageList, setLoadingVillageList] = useState<boolean>(true);
 
   const { data: countryEngagementStatus, isLoading: isLoadingCountryEngagementStatus } = useGetCountryEngagementStatus(selectedCountry);
   const { data: classroomsStatistics, isLoading: isLoadingClassroomStatistics } = useStatisticsClassrooms(null, selectedCountry, null);
@@ -36,6 +43,7 @@ const CountryStats = () => {
   const { data: engagementStatusStatistics, isLoading: isLoadingEngagementStatusStatistics } = useGetClassroomsEngagementStatus({
     countryCode: selectedCountry,
   });
+  const { data: villages, isLoading: isLoadingVillages } = useGetVillages(selectedCountry);
 
   // On mocke l'asynchronisme en attendant d'avoir l'appel serveur censé retourner les interactions des villages-mondes
   // A refacto lors de l'implémentation des tickets VIL-407 et VIL-63
@@ -53,29 +61,16 @@ const CountryStats = () => {
         { country: 'Roumanie', total: 10 },
       ];
 
-      const fakeVillageListData = [
-        { name: 'Village France - Canada', color: 'green' },
-        { name: 'Village France - Liban', color: 'orange' },
-        { name: 'Village France - Italie', color: 'gold' },
-        { name: 'Village France - Hongrie', color: 'yellow' },
-        { name: 'Village France - Belgique', color: 'green' },
-        { name: 'Village France - Angleterre', color: 'limegreen' },
-        { name: 'Village France - Mexique', color: 'blue' },
-        { name: 'Village France - Russie', color: 'red' },
-        { name: 'Village France - Australie', color: 'orange' },
-      ];
-
       setHighlightedCountry(fakeHighlightedCountry);
       setLoadingHighlightedCountry(false);
       setBarsChartData(fakeContributionsByCountry);
       setLoadingBarsChartData(false);
-      setVillageList(fakeVillageListData);
-      setLoadingVillageList(false);
     }, 5000);
   }, []);
 
-  const isLoadingCountryStatistics = isLoadingCountryEngagementStatus || loadingHighlightedCountry || loadingBarsChartData || loadingVillageList;
+  const isLoadingCountryStatistics = isLoadingCountryEngagementStatus || loadingHighlightedCountry || loadingBarsChartData || isLoadingVillages;
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const onCountrySelect = (_country: string) => {
     // TODO VIL-815 changer la valeur de selectedCountry quand on clique sur une barre du graphique
   };
@@ -88,7 +83,7 @@ const CountryStats = () => {
         <PelicoCard message={'Merci de sélectionner un pays pour analyser ses statistiques'} />
       ) : (
         <Box mt={2}>
-          {isLoadingCountryStatistics ? (
+          {isLoadingCountryStatistics || isLoadingVillages ? (
             <Loader analyticsDataType={AnalyticsDataType.GRAPHS} />
           ) : (
             <>
@@ -98,7 +93,15 @@ const CountryStats = () => {
                   <HorizontalBarsChart highlightedCountry={highlightedCountry} barsChartData={barsChartData} onCountrySelect={onCountrySelect} />
                 </div>
               )}
-              {villageList && <VillageListCard villageList={villageList} />}
+              {villages && (
+                <VillageListCard
+                  villageList={villages}
+                  selectedCountry={selectedCountry}
+                  onVillageClick={(villageId, selectedCountry) => {
+                    onVillageSelect?.(villageId, selectedCountry);
+                  }}
+                />
+              )}
             </>
           )}
           {isLoadingClassroomStatistics || isLoadingSessionsStatistics || isLoadingFamilyStatistics || isLoadingEngagementStatusStatistics ? (

--- a/src/components/admin/dashboard-statistics/DashboardStatsNav.tsx
+++ b/src/components/admin/dashboard-statistics/DashboardStatsNav.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import Box from '@mui/material/Box';
 import Tab from '@mui/material/Tab';
@@ -39,16 +39,30 @@ function a11yProps(index: number) {
 }
 
 const DashboardStatsNav = () => {
-  const [value, setValue] = React.useState(0);
+  const [tabValue, setTabValue] = useState(0);
+  const [selectedCountry, setSelectedCountry] = useState<string | undefined>();
+  const [selectedVillage, setSelectedVillage] = useState<number | undefined>();
 
   const handleChange = (_event: React.SyntheticEvent, newValue: number) => {
-    setValue(newValue);
+    setTabValue(newValue);
+  };
+
+  // Callback passé à CountryStats (optionnel, utilisé seulement si clic village-monde)
+  const handleVillageSelectFromList = (villageId: number, countryCode?: string) => {
+    setSelectedVillage(villageId);
+    setSelectedCountry(countryCode);
+    setTabValue(2); // Aller sur l’onglet "Village-monde"
+  };
+
+  const resetVillageFilters = () => {
+    setSelectedCountry(undefined);
+    setSelectedVillage(undefined);
   };
 
   return (
     <Box sx={{ width: '100%' }}>
       <Box sx={{ borderBottom: 1, marginBottom: 2, borderColor: 'divider' }}>
-        <Tabs value={value} onChange={handleChange} aria-label="basic tabs example">
+        <Tabs value={tabValue} onChange={handleChange} aria-label="basic tabs example">
           <Tab label="1Village" {...a11yProps(0)} />
           <Tab label="Pays" {...a11yProps(1)} />
           <Tab label="Village-monde" {...a11yProps(2)} />
@@ -56,19 +70,19 @@ const DashboardStatsNav = () => {
           <Tab label="Données" {...a11yProps(4)} />
         </Tabs>
       </Box>
-      <CustomTabPanel value={value} index={0}>
+      <CustomTabPanel value={tabValue} index={0}>
         <GlobalStats />
       </CustomTabPanel>
-      <CustomTabPanel value={value} index={1}>
-        <CountryStats />
+      <CustomTabPanel value={tabValue} index={1}>
+        <CountryStats onVillageSelect={handleVillageSelectFromList} />
       </CustomTabPanel>
-      <CustomTabPanel value={value} index={2}>
-        <VillageStats />
+      <CustomTabPanel value={tabValue} index={2}>
+        <VillageStats selectedCountry={selectedCountry} selectedVillage={selectedVillage} onResetFilters={resetVillageFilters} />
       </CustomTabPanel>
-      <CustomTabPanel value={value} index={3}>
+      <CustomTabPanel value={tabValue} index={3}>
         <ClassroomStats />
       </CustomTabPanel>
-      <CustomTabPanel value={value} index={4}>
+      <CustomTabPanel value={tabValue} index={4}>
         <DataDetailsStats />
       </CustomTabPanel>
     </Box>

--- a/src/components/admin/dashboard-statistics/VillageStats.tsx
+++ b/src/components/admin/dashboard-statistics/VillageStats.tsx
@@ -32,11 +32,17 @@ import { useStatisticsClassrooms, useStatisticsSessions } from 'src/services/use
 import type { OneVillageTableRow } from 'types/statistics.type';
 import { TeamCommentType } from 'types/teamComment.type';
 
-const VillageStats = () => {
+interface VillageStatsProps {
+  selectedCountry?: string;
+  selectedVillage?: number;
+  onResetFilters?: () => void;
+}
+
+const VillageStats: React.FC<VillageStatsProps> = ({ selectedCountry: initialCountry, selectedVillage: initialVillage, onResetFilters }) => {
   const [selectedTab, setSelectedTab] = useState(0);
   const [selectedPhase, setSelectedPhase] = useState<number>();
-  const [selectedCountry, setSelectedCountry] = useState<string>();
-  const [selectedVillage, setSelectedVillage] = useState<number>();
+  const [selectedCountry, setSelectedCountry] = useState<string | undefined>(initialCountry);
+  const [selectedVillage, setSelectedVillage] = useState<number | undefined>(initialVillage);
   const [familiesWithoutAccountRows, setFamiliesWithoutAccountRows] = useState<Array<OneVillageTableRow>>([]);
   const [openPhases, setOpenPhases] = useState<Record<number, boolean>>({
     1: false,
@@ -59,6 +65,19 @@ const VillageStats = () => {
   const videoCount = getVideoCount(villageStatistics);
   const commentCount = getCommentCount(villageStatistics);
   const publicationCount = getPublicationCount(villageStatistics);
+
+  // Pour éviter de ré-appliquer les props à chaque changement, on ne synchronise qu'au premier render :
+  useEffect(() => {
+    if (initialCountry !== undefined) setSelectedCountry(initialCountry);
+    if (initialVillage !== undefined) setSelectedVillage(initialVillage);
+  }, [initialCountry, initialVillage]);
+
+  useEffect(() => {
+    // Cleanup au démontage
+    return () => {
+      if (onResetFilters) onResetFilters();
+    };
+  }, [onResetFilters]);
 
   useEffect(() => {
     if (villageStatistics?.family?.familiesWithoutAccount) {
@@ -111,7 +130,13 @@ const VillageStats = () => {
   return (
     <>
       <TeamCommentCard type={TeamCommentType.VILLAGE} />
-      <StatisticFilters onPhaseChange={setSelectedPhase} onCountryChange={setSelectedCountry} onVillageChange={setSelectedVillage} />
+      <StatisticFilters
+        onPhaseChange={setSelectedPhase}
+        onCountryChange={setSelectedCountry}
+        onVillageChange={setSelectedVillage}
+        selectedCountry={selectedCountry}
+        selectedVillage={selectedVillage}
+      />
       {selectedCountry && selectedVillage ? (
         <>
           {isLoadingGraphsData ? (

--- a/src/components/admin/dashboard-statistics/cards/VillageListCard/VillageListCard.tsx
+++ b/src/components/admin/dashboard-statistics/cards/VillageListCard/VillageListCard.tsx
@@ -1,22 +1,62 @@
 import styles from './VillageListCard.module.css'; // Import du CSS modulaire
-import type { VillageListItem } from 'types/analytics/village-list-item';
+import { useGetVillageEngagementStatus } from 'src/api/statistics/statistics.get';
+import type { EngagementStatus } from 'types/statistics.type';
+import { EngagementStatusColor } from 'types/statistics.type';
+import type { Village } from 'types/village.type';
 
 interface VillageListCardProps {
-  villageList: VillageListItem[];
+  villageList: Village[];
+  selectedCountry?: string;
+  onVillageClick?: (villageId: number, countryCode?: string) => void;
 }
 
-const VillageListCard = ({ villageList }: Readonly<VillageListCardProps>) => {
+const mapStatusToColor = (status?: EngagementStatus) => {
+  if (!status) return 'gray';
+  const statusKey = status.toUpperCase() as keyof typeof EngagementStatusColor;
+  return EngagementStatusColor[statusKey] || 'gray';
+};
+
+const VillageListCard = ({ villageList, selectedCountry, onVillageClick }: Readonly<VillageListCardProps>) => {
   return (
     <div className={styles.villageListContainer}>
       <h3>Ce pays participe dans les villages-monde suivants :</h3>
       <div className={styles.villageList}>
         {villageList.map((village) => (
-          <div key={village.name} className={styles.villageItem}>
-            <span className={styles.villageBullet} style={{ backgroundColor: village.color }}></span>
-            <a href="#">{village.name}</a>
-          </div>
+          <VillageItem
+            key={village.id}
+            village={village}
+            selectedCountry={selectedCountry}
+            onClick={() => onVillageClick?.(village.id, selectedCountry)}
+          />
         ))}
       </div>
+    </div>
+  );
+};
+
+interface VillageItemProps {
+  village: Village;
+  selectedCountry?: string;
+  onClick?: (villageId: number, countryCode?: string) => void;
+}
+
+const VillageItem = ({ village, selectedCountry, onClick }: VillageItemProps) => {
+  const { data: status, isLoading } = useGetVillageEngagementStatus(village.id);
+
+  const color = isLoading ? 'gray' : mapStatusToColor(status);
+
+  return (
+    <div className={styles.villageItem}>
+      <span className={styles.villageBullet} style={{ backgroundColor: color }}></span>
+      <a
+        href="#"
+        onClick={(e) => {
+          e.preventDefault();
+          onClick && onClick(village.id, selectedCountry);
+        }}
+      >
+        {village.name}
+      </a>
     </div>
   );
 };

--- a/src/components/admin/dashboard-statistics/filters/Dropdown.tsx
+++ b/src/components/admin/dashboard-statistics/filters/Dropdown.tsx
@@ -20,9 +20,7 @@ export default function Dropdown({ data, onItemChange, label, showNone = true, s
   const [item, setItem] = useState('');
 
   useEffect(() => {
-    if (selectedItem === undefined) {
-      setItem('');
-    }
+    setItem(selectedItem ?? '');
   }, [selectedItem]);
 
   const handleChange = (event: SelectChangeEvent) => {

--- a/src/components/admin/dashboard-statistics/filters/StatisticFilters.tsx
+++ b/src/components/admin/dashboard-statistics/filters/StatisticFilters.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 
 import Grid from '@mui/material/Grid';
 
@@ -14,12 +14,30 @@ type StatisticFiltersProps = {
   onCountryChange?: (countryCode: string) => void;
   onVillageChange?: (villageId: number) => void;
   onClassroomChange?: (classroomId: number) => void;
+  selectedCountry?: string;
+  selectedVillage?: number;
 };
 
-export default function StatisticFilters({ onPhaseChange, onCountryChange, onVillageChange, onClassroomChange }: StatisticFiltersProps) {
-  const [selectedCountry, setSelectedCountry] = useState<string>();
-  const [selectedVillage, setSelectedVillage] = useState<number>();
+export default function StatisticFilters({
+  onPhaseChange,
+  onCountryChange,
+  onVillageChange,
+  onClassroomChange,
+  selectedCountry: initialCountry,
+  selectedVillage: initialVillage,
+}: StatisticFiltersProps) {
+  const [selectedCountry, setSelectedCountry] = useState<string | undefined>(initialCountry);
+  const [selectedVillage, setSelectedVillage] = useState<number | undefined>(initialVillage);
   const [selectedClassroom, setSelectedClassroom] = useState<number>();
+
+  useEffect(() => {
+    if (initialCountry !== undefined) {
+      setSelectedCountry(initialCountry);
+    }
+    if (initialVillage !== undefined) {
+      setSelectedVillage(initialVillage);
+    }
+  }, [initialCountry, initialVillage]);
 
   // PHASE
   const phaseDropdownOptions = [


### PR DESCRIPTION
### Motivation

connecter la liste des village-monde sur l'onglet PAYS, et naviguer depuis la liste vers l'onglet VILLAGE-MONDE
https://parlemonde.atlassian.net/browse/VIL-63

### Changes

- charger la liste des village-monde selon le pays sélectionné
- charger le statut des village-monde
- mettre en place la navigation depuis la liste vers l'onglet VILLAGE-MONDE filtré sur le village-monde en question

### Test

Sur l'onglet PAYS: sélectionner un pays -> constater le chargement de la liste des village-monde avec les pastilles des statuts associés
Cliquer sur un village-monde depuis la liste, et constater la navigation vers le village-monde cliqué
