### PR TITLE
feat(VIL-65): connect the Classroom Identity section

### DIFF
--- a/server/controllers/statistics/statistics.ts
+++ b/server/controllers/statistics/statistics.ts
@@ -16,6 +16,7 @@ import {
   getFamiliesWithoutAccountForClassroom,
   getContributedClassroomsCount,
   getContributionsBarChartData,
+  getClassroomIdentity,
 } from '../../stats/classroomStats';
 import { getFamiliesWithoutAccountForCountry } from '../../stats/countryStats';
 import { getFamiliesWithoutAccountForGlobal } from '../../stats/globalStats';
@@ -380,6 +381,27 @@ statisticsController.get({ path: '/classrooms/details/:classroomId' }, async (re
     .getRawOne<ClassroomDetails>();
 
   res.sendJSON(classroomDetails);
+});
+
+statisticsController.get({ path: '/classrooms-identity/:classroomId' }, async (req, res) => {
+  try {
+    const classroomId = parseInt(req.params.classroomId);
+    if (isNaN(classroomId)) {
+      res.status(400).send(`L'identifiant de la classe est invalide.`);
+      return;
+    }
+
+    const classroomDetails = await getClassroomIdentity(classroomId);
+
+    if (!classroomDetails) {
+      return res.status(404).send('Error 404 - Not found.');
+    }
+
+    return res.status(200).json(classroomDetails);
+  } catch (error) {
+    console.error('Error fetching classroom identity:', error);
+    return res.status(500).json({ message: 'Internal server error' });
+  }
 });
 
 statisticsController.get({ path: '/one-village' }, async (req, res) => {

--- a/src/api/statistics/statistics.get.ts
+++ b/src/api/statistics/statistics.get.ts
@@ -12,6 +12,7 @@ import type {
   ClassroomToMonitor,
   EngagementStatusParams,
   EngagementStatusData,
+  ClassroomIdentityDetails,
 } from 'types/statistics.type';
 
 async function getSessionsStats(phase?: number): Promise<SessionsStats> {
@@ -299,4 +300,20 @@ export function useGetCompareClassroomsStats(villageId: number, phase: number) {
   return useQuery<ClassroomCompareData[]>(['compare-classes-stats', villageId, phase], () => getCompareClassroomsStats(villageId, phase), {
     enabled: !!villageId && !!phase,
   });
+}
+
+export function useGetClassroomIdentity(classroomId?: Classroom['id']) {
+  return useQuery(['classroom-details', classroomId], () => getClassroomIdentity(classroomId), {
+    enabled: classroomId !== null,
+  });
+}
+
+async function getClassroomIdentity(classroomId?: Classroom['id']): Promise<ClassroomIdentityDetails> {
+  return (
+    await axiosRequest({
+      method: 'GET',
+      baseURL: '/api',
+      url: `/statistics/classrooms-identity/${classroomId}`,
+    })
+  ).data;
 }

--- a/src/components/admin/dashboard-statistics/ClassroomStats.tsx
+++ b/src/components/admin/dashboard-statistics/ClassroomStats.tsx
@@ -18,8 +18,7 @@ import { PelicoCard } from './pelico-card';
 import styles from './styles/charts.module.css';
 import { createFamiliesWithoutAccountRows } from './utils/tableCreator';
 import { FamiliesWithoutAccountHeaders } from './utils/tableHeader';
-import { useGetClassroomDetails, useGetClassroomEngagementStatus, useGetClassroomsStats } from 'src/api/statistics/statistics.get';
-import { useStatisticsSessions } from 'src/services/useStatistics';
+import { useGetClassroomIdentity, useGetClassroomEngagementStatus, useGetClassroomsStats } from 'src/api/statistics/statistics.get';
 import type { OneVillageTableRow } from 'types/statistics.type';
 import { TeamCommentType } from 'types/teamComment.type';
 
@@ -36,13 +35,13 @@ const ClassroomStats = () => {
     3: true,
   });
 
+  const { data: classroomIdentityDetails, isLoading: isLoadingClassroomIdentityDetails } = useGetClassroomIdentity(selectedClassroom);
   const { data: classroomEngagementStatus, isLoading: isLoadingClassroomEngagementStatus } = useGetClassroomEngagementStatus(selectedClassroom);
-  const { data: _sessionsStatistics, isLoading: isLoadingSessionsStatistics } = useStatisticsSessions(null, null, 1);
+  //const { data: _sessionsStatistics, isLoading: isLoadingSessionsStatistics } = useStatisticsSessions(null, null, 1);
   const { data: selectedClassroomStatistics, isLoading: isLoadingSelectedClassroomsStatistics } = useGetClassroomsStats(
     selectedClassroom,
     selectedPhase,
   );
-  const { data: classroomDetails, isLoading: isLoadingClassroomDetail } = useGetClassroomDetails(selectedClassroom);
 
   const totalActivitiesCounts = selectedClassroomStatistics?.totalActivityCounts;
 
@@ -67,17 +66,17 @@ const ClassroomStats = () => {
       />
       {selectedCountry && selectedVillage && selectedClassroom ? (
         <Box mt={2}>
-          {isLoadingClassroomEngagementStatus || isLoadingClassroomDetail ? (
+          {isLoadingClassroomEngagementStatus || isLoadingClassroomIdentityDetails ? (
             <Loader analyticsDataType={AnalyticsDataType.GRAPHS} />
           ) : (
             <>
               {classroomEngagementStatus && (
                 <EntityEngagementStatus entityType={EntityType.CLASSROOM} entityEngagementStatus={classroomEngagementStatus} />
               )}
-              {classroomDetails && <ClassroomDetailsCard classroomDetails={classroomDetails} />}
+              {classroomIdentityDetails && <ClassroomDetailsCard classroomIdentityDetails={classroomIdentityDetails} />}
             </>
           )}
-          {isLoadingSessionsStatistics || isLoadingSelectedClassroomsStatistics ? (
+          {isLoadingSelectedClassroomsStatistics ? (
             <Loader analyticsDataType={AnalyticsDataType.WIDGETS} />
           ) : (
             <>

--- a/src/components/admin/dashboard-statistics/cards/ClassroomDetailsCard/ClassroomDetailsCard.tsx
+++ b/src/components/admin/dashboard-statistics/cards/ClassroomDetailsCard/ClassroomDetailsCard.tsx
@@ -2,46 +2,39 @@ import React from 'react';
 
 import CountryMap from '../../map/CountryMap/CountryMap';
 import styles from './ClassroomDetailsCard.module.css';
-import type { ClassroomDetails } from 'types/statistics.type';
+import { UserContext } from 'src/contexts/userContext';
+import { toDate } from 'src/utils';
+import type { ClassroomIdentityDetails } from 'types/statistics.type';
+import { UserType } from 'types/user.type';
 
 interface ClassroomDetailsCardProps {
-  classroomDetails?: ClassroomDetails;
+  classroomIdentityDetails: ClassroomIdentityDetails;
 }
 
-const ClassroomDetailsCard = ({ classroomDetails }: ClassroomDetailsCardProps) => {
-  if (!classroomDetails) {
-    return (
-      <div className={`${styles.root} ${styles.mainContainer}`}>
-        <CountryMap countryIso2="VN" />
-        <div className={styles.infoContainer}>
-          <h3>Détails de la classe</h3>
-          <p>Sélectionnez une classe pour voir ses détails</p>
-        </div>
-      </div>
-    );
-  }
+const ClassroomDetailsCard = ({ classroomIdentityDetails: classroomDetails }: ClassroomDetailsCardProps) => {
+  const { user } = React.useContext(UserContext);
+  const isObservator = user !== null && user.type === UserType.OBSERVATOR;
 
   return (
-    <div className={`${styles.root} ${styles.mainContainer}`}>
-      <CountryMap countryIso2={classroomDetails.countryCode || 'VN'} />
+    <div className={styles.mainContainer}>
+      <CountryMap classroomDetails={classroomDetails} />
       <div className={styles.infoContainer}>
-        <h3>Détails de la classe</h3>
+        <h1>École {classroomDetails.school}</h1>
         <ul>
           <li>
-            <strong>Nom de la classe :</strong> {classroomDetails.classroomName}
+            Adresse: {classroomDetails.address}, {classroomDetails.postalCode} {classroomDetails.city}
           </li>
-          <li>
-            <strong>Pays :</strong> {classroomDetails.countryCode}
-          </li>
-          <li>
-            <strong>Village :</strong> {classroomDetails.villageName}
-          </li>
-          <li>
-            <strong>Nombre de commentaires :</strong> {classroomDetails.commentsCount}
-          </li>
-          <li>
-            <strong>Nombre de vidéos :</strong> {classroomDetails.videosCount}
-          </li>
+          <li>Pays: {classroomDetails.country?.name}</li>
+          <li>Village Monde: {classroomDetails.village}</li>
+          {!isObservator && (
+            <>
+              <li>Adresse Mail: {classroomDetails.email}</li>
+              <li>Dernière connexion: {toDate(classroomDetails.lastConnexion as string)} </li>
+              <li>
+                Professeur: {classroomDetails.firstname} {classroomDetails.lastname}
+              </li>
+            </>
+          )}
         </ul>
       </div>
     </div>

--- a/src/components/admin/dashboard-statistics/map/CountryMap/CountryMap.tsx
+++ b/src/components/admin/dashboard-statistics/map/CountryMap/CountryMap.tsx
@@ -1,42 +1,21 @@
-import { geoPath, geoMercator } from 'd3-geo';
-import type { FeatureCollection } from 'geojson';
 import React from 'react';
-import { useQuery } from 'react-query';
 
-import styles from './CountryMap.module.css';
+import { Map } from 'src/components/Map';
+import type { ClassroomIdentityDetails } from 'types/statistics.type';
 
 interface CountryMapProps {
-  countryIso2: string;
+  classroomDetails: ClassroomIdentityDetails;
 }
 
-const CountryMap = ({ countryIso2 }: CountryMapProps) => {
-  const getSvgPath = async () => {
-    const response = await fetch('/earth/countries.geo.json');
-    const geojson: FeatureCollection = await response.json();
-
-    const country = geojson.features.find((feature) => feature.properties && feature.properties.iso2 === countryIso2);
-
-    if (country) {
-      const projection = geoMercator().fitSize([800, 600], country);
-      const pathGenerator = geoPath().projection(projection);
-      const svgPath = pathGenerator(country);
-
-      return svgPath;
-    }
-
-    return undefined;
-  };
-
-  const { data, isIdle, isLoading, isError } = useQuery('svg-coutry-path', getSvgPath);
-
-  if (isIdle || isLoading) return <p>Loading...</p>;
-  if (isError) return <p>Error !</p>;
-
+const CountryMap = ({ classroomDetails }: CountryMapProps) => {
   return (
-    <div className={styles.container}>
-      <svg viewBox="0 0 900 700" width="75%" height="75%">
-        <path d={data ? data : ''} fill="#DAD7FE" x="50%" y="50%" />
-      </svg>
+    <div style={{ flex: 1, height: '300px', borderRadius: '10px', overflow: 'hidden' }}>
+      <Map
+        key={classroomDetails.school}
+        position={classroomDetails.position}
+        zoom={3}
+        markers={[{ position: classroomDetails.position, label: classroomDetails.address, activityCreatorMascotte: undefined }]}
+      />
     </div>
   );
 };

--- a/types/statistics.type.ts
+++ b/types/statistics.type.ts
@@ -1,3 +1,4 @@
+import type { Country } from './country.type';
 import type { ContributionBarChartData } from './dashboard.type';
 import type { User } from './user.type';
 import type { Village, VillagePhase } from './village.type';
@@ -202,4 +203,21 @@ export enum EngagementStatusColor {
   GHOST = '#FFD678',
   OBSERVER = '#6082FC',
   ACTIVE = '#4CC64A',
+}
+
+export interface ClassroomIdentityDetails {
+  school: string;
+  country: Country | null;
+  email: string;
+  firstname: string;
+  lastname: string;
+  city: string;
+  postalCode: string;
+  address: string;
+  position: {
+    lat: number;
+    lng: number;
+  };
+  village: string;
+  lastConnexion: string | Date;
 }


### PR DESCRIPTION
### Motivation

Charger les informations de la carte d'identité de la classe ainsi que la map associée
https://parlemonde.atlassian.net/browse/VIL-65

### Changes

- Ajouter la requête permettant de charger les données
- les services et appels associés
- charger les données dans la carte d'identité
- cacher les données du PROFESSEUR pour le les utilisateurs de type OBSERVATEUR
- changer le type de la map, et positionner la classe sur la map


### Test

Aller dans l'onglet CLASSE du Dashboard -> et constater le chargement des infos + carte de la carte d'identité de la classe sélectionnée