### PR TITLE
[VIL-998] bugfix contenu-libre pass wrong isPelico value

### DIFF
--- a/src/app/(1village)/(activities)/contenu-libre/page.tsx
+++ b/src/app/(1village)/(activities)/contenu-libre/page.tsx
@@ -12,6 +12,7 @@ export default function FreeContent() {
     const { user } = useContext(UserContext);
     const { onCreateActivity } = useContext(ActivityContext);
     const router = useRouter();
+    const isPelico = user.role === 'admin' || user.role === 'mediator';
 
     return (
         <PageContainer title="Publication de contenu libre">
@@ -25,7 +26,7 @@ export default function FreeContent() {
                     label="Étape suivante"
                     rightIcon={<ChevronRightIcon />}
                     onClick={() => {
-                        onCreateActivity('libre', user.role === 'admin' || user.role === 'teacher');
+                        onCreateActivity('libre', isPelico);
                         router.push('/contenu-libre/1');
                     }}
                 />


### PR DESCRIPTION
Les activités de type contenu libre s’affichent comme une activité publiée par Pelico même lorsque c’est un prof qui la publie

JIRA: https://parlemonde.atlassian.net/browse/VIL-998